### PR TITLE
[Ubuntu build] Reload existing setting when Yocto changes env setting - @open sesame 08/16 19:25

### DIFF
--- a/ci/standalone/plugins-base/pr-audit-build-ubuntu.sh
+++ b/ci/standalone/plugins-base/pr-audit-build-ubuntu.sh
@@ -52,6 +52,8 @@ function pr-audit-build-ubuntu(){
     echo "########################################################################################"
     echo "[MODULE] TAOS/pr-audit-build-ubuntu: check build process for Ubuntu distribution"
 
+    echo "source /etc/environment"
+    source /etc/environment
     # check if dependent packages are installed
     # the required packages are pbuilder(pdebuild), debootstrap(debootstrap), and devscripts(debuild)
     check_dependency sudo


### PR DESCRIPTION

This commit is to handle correctly the default enviromment variables
in case that envrionment is suddenly changed due to Yocto/Poky eSDK.

**Changes proposed in this PR:**
1. Added /etc/environment for ubuntu build

Signed-off-by: Geunsik Lim <leemgs@gmail.com>


---
# [Template] PR Description

In general, github system automatically copies your commit message for your convenience.
Please remove unused part of the template after writing your own PR description with this template.
```bash
$ git commit -s filename1 filename2 ... [enter]

Summarize changes in around 50 characters or less

More detailed explanatory text, if necessary. Wrap it to about 72
characters or so. In some contexts, the first line is treated as the
subject of the commit and the rest of the text as the body. The
blank line separating the summary from the body is critical;
various tools like `log`, `shortlog` and `rebase` can get confused 
if you run the two together.

Further paragraphs come after blank lines.

**Changes proposed in this PR:**
- Bullet points are okay, too
- Typically a hyphen or asterisk is used for the bullet, preceded
  by a single space, with blank lines in between, but conventions vary here.

Resolves: #123
See also: #456, #789

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped

**How to evaluate:**
1. Describe how to evaluate in order to be reproduced by reviewer(s).

Add signed-off message automatically by running **$git commit -s ...** command.

$ git push origin <your_branch_name>
```
