### PR TITLE
[Audit] Reorganize queue structure of platform package builder

### DIFF
--- a/ci/taos/plugins-base/pr-audit-build-tizen.sh
+++ b/ci/taos/plugins-base/pr-audit-build-tizen.sh
@@ -23,22 +23,23 @@
 # @requirement
 # $ sudo apt install gbs
 
-# @brief [MODULE] TAOS/pr-audit-build-tizen-trigger-queue
-function pr-audit-build-tizen-trigger-queue(){
-    message="Trigger: queued. There are other build jobs and we need to wait.. The commit number is $input_commit."
+# @brief [MODULE] TAOS/pr-audit-build-tizen-wait-queue
+function pr-audit-build-tizen-wait-queue(){
+    message="Trigger: wait queue. There are other build jobs and we need to wait.. The commit number is $input_commit."
     cibot_pr_report $TOKEN "pending" "TAOS/pr-audit-build-tizen-$1" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
 }
 
-# @brief [MODULE] TAOS/pr-audit-build-tizen-trigger-run
-function pr-audit-build-tizen-trigger-run(){
-    echo "[DEBUG] Starting CI trigger to run 'gbs build -A $1 (for Tizen)' command actually."
-    message="Trigger: running. The commit number is $input_commit."
+# @brief [MODULE] TAOS/pr-audit-build-tizen-ready-queue
+function pr-audit-build-tizen-ready-queue(){
+    message="Trigger: ready queue. The commit number is $input_commit."
     cibot_pr_report $TOKEN "pending" "TAOS/pr-audit-build-tizen-$1" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
 }
 
-# @brief [MODULE] TAOS/pr-audit-build-tizen
-function pr-audit-build-tizen(){
-    ## [MODULE] TAOS/pr-audit-build-tizen: Check if 'gbs build' can be successfully passed.
+# @brief [MODULE] TAOS/pr-audit-build-tizen-run-queue
+function pr-audit-build-tizen-run-queue(){
+    message="Trigger: run queue. The commit number is $input_commit."
+    cibot_pr_report $TOKEN "pending" "TAOS/pr-audit-build-tizen-$1" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+
     echo "[MODULE] TAOS/pr-audit-build-tizen-$1: Check if 'gbs build -A $1' can be successfully passed."
     pwd
 
@@ -48,7 +49,6 @@ function pr-audit-build-tizen(){
     check_dependency curl
     check_dependency gbs
     check_dependency tee
-
 
     # BUILD_MODE=0 : run "gbs build" command without generating debugging information.
     # BUILD_MODE=1 : run "gbs build" command with a debug file.

--- a/ci/taos/plugins-base/pr-audit-build-ubuntu.sh
+++ b/ci/taos/plugins-base/pr-audit-build-ubuntu.sh
@@ -34,21 +34,23 @@
 # $ sudo pbuilder create
 # $ ls -al /var/cache/pbuilder/base.tgz
 
-# @brief [MODULE] TAOS/pr-audit-build-ubuntu-trigger-queue
-function pr-audit-build-ubuntu-trigger-queue(){
-    message="Trigger: queued. There are other build jobs and we need to wait.. The commit number is $input_commit."
+# @brief [MODULE] TAOS/pr-audit-build-ubuntu-wait-queue
+function pr-audit-build-ubuntu-wait-queue(){
+    message="Trigger: wait queue. There are other build jobs and we need to wait.. The commit number is $input_commit."
     cibot_pr_report $TOKEN "pending" "TAOS/pr-audit-build-ubuntu" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
 }
 
-# @brief [MODULE] TAOS/pr-audit-build-ubuntu-trigger-run
-function pr-audit-build-ubuntu-trigger-run(){
-    echo "[DEBUG] Starting CI trigger to run 'pdebuild (for Ubuntu)' command actually."
-    message="Trigger: running. The commit number is $input_commit."
+# @brief [MODULE] TAOS/pr-audit-build-ubuntu-ready-queue
+function pr-audit-build-ubuntu-ready-queue(){
+    message="Trigger: ready queue. The commit number is $input_commit."
     cibot_pr_report $TOKEN "pending" "TAOS/pr-audit-build-ubuntu" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
 }
 
-# @brief [MODULE] TAOS/pr-audit-build-ubuntu
-function pr-audit-build-ubuntu(){
+# @brief [MODULE] TAOS/pr-audit-build-ubuntu-run-queue
+function pr-audit-build-ubuntu-run-queue(){
+    message="Trigger: run queue. The commit number is $input_commit."
+    cibot_pr_report $TOKEN "pending" "TAOS/pr-audit-build-ubuntu" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+
     echo "########################################################################################"
     echo "[MODULE] TAOS/pr-audit-build-ubuntu: check build process for Ubuntu distribution"
 

--- a/ci/taos/plugins-base/pr-audit-build-yocto.sh
+++ b/ci/taos/plugins-base/pr-audit-build-yocto.sh
@@ -46,21 +46,23 @@
 # $ devtool reset hello-world-sample
 #
 
-# @brief [MODULE] TAOS/pr-audit-build-yocto-trigger-queue
-function pr-audit-build-yocto-trigger-queue(){
-    message="Trigger: queued. There are other build jobs and we need to wait.. The commit number is $input_commit."
+# @brief [MODULE] TAOS/pr-audit-build-yocto-wait-queue
+function pr-audit-build-yocto-wait-queue(){
+    message="Trigger: wait queue. There are other build jobs and we need to wait.. The commit number is $input_commit."
     cibot_pr_report $TOKEN "pending" "TAOS/pr-audit-build-yocto" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
 }
 
-# @brief [MODULE] TAOS/pr-audit-build-yocto-trigger-run
-function pr-audit-build-yocto-trigger-run(){
-    echo "[DEBUG] Starting CI trigger to run 'devtool (for YOCTO)' command actually."
-    message="Trigger: running. The commit number is $input_commit."
+# @brief [MODULE] TAOS/pr-audit-build-yocto-ready-queue
+function pr-audit-build-yocto-ready-queue(){
+    message="Trigger: ready queue. The commit number is $input_commit."
     cibot_pr_report $TOKEN "pending" "TAOS/pr-audit-build-yocto" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
 }
 
-# @brief [MODULE] TAOS/pr-audit-build-yocto
-function pr-audit-build-yocto(){
+# @brief [MODULE] TAOS/pr-audit-build-yocto-run-queue
+function pr-audit-build-yocto-run-queue(){
+    message="Trigger: run queue. The commit number is $input_commit."
+    cibot_pr_report $TOKEN "pending" "TAOS/pr-audit-build-yocto" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+
     echo "########################################################################################"
     echo "[MODULE] TAOS/pr-audit-build-yocto: check build process for YOCTO distribution"
 


### PR DESCRIPTION
This commit is to reorganize a queue structure of the existing platform
package builder. The three job queues handle a job status of the commit requests
that are managed by the commit scheduler.

* Before: wait trigger and run trigger
* After : wait, ready, and run queue

**Changes proposed in this PR:**
1. Added web hook apis additioanlly
2. Updated annotations
3. Updated the existing queue structure
4. Renamed a build queue by appending postfix '-run-queue'

Signed-off-by: Geunsik Lim <leemgs@gmail.com>


---
# [Template] PR Description

In general, github system automatically copies your commit message for your convenience.
Please remove unused part of the template after writing your own PR description with this template.
```bash
$ git commit -s filename1 filename2 ... [enter]

Summarize changes in around 50 characters or less

More detailed explanatory text, if necessary. Wrap it to about 72
characters or so. In some contexts, the first line is treated as the
subject of the commit and the rest of the text as the body. The
blank line separating the summary from the body is critical;
various tools like `log`, `shortlog` and `rebase` can get confused 
if you run the two together.

Further paragraphs come after blank lines.

**Changes proposed in this PR:**
- Bullet points are okay, too
- Typically a hyphen or asterisk is used for the bullet, preceded
  by a single space, with blank lines in between, but conventions vary here.

Resolves: #123
See also: #456, #789

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped

**How to evaluate:**
1. Describe how to evaluate in order to be reproduced by reviewer(s).

Add signed-off message automatically by running **$git commit -s ...** command.

$ git push origin <your_branch_name>
```
