### PR TITLE
[Yocto] Check required package of eSDK absence

### DIFF
--- a/ci/taos/plugins-base/pr-audit-build-yocto.sh
+++ b/ci/taos/plugins-base/pr-audit-build-yocto.sh
@@ -96,9 +96,11 @@ function pr-audit-build-yocto-run-queue(){
  
     # Check if dependent packages are installed
     # The required packages are sudo, curl, and eYOCTO(devtool)
-    check_dependency sudo
-    check_dependency curl
-    check_dependency devtool
+    if [[ $YOCTO_ESDK_ROOT != "" ]]; then
+        check_dependency sudo
+        check_dependency curl
+        check_dependency devtool
+    fi
 
     echo "[DEBUG] env information: start ---------------------------------------------"
     env
@@ -124,7 +126,7 @@ function pr-audit-build-yocto-run-queue(){
         # '888' will be used for a fine-graind classification when the values of 'build_result' are increased.
         build_result=888
     else
-        # build package with devtool
+        # Build a package with devtool. The devtool command requires root privilege.
         # Note that you have to set no-password condition after running 'visudo' command.
         # www-data    ALL=(ALL) NOPASSWD:ALL
         echo -e "[DEBUG] The current folder is $(pwd)."


### PR DESCRIPTION
Fixes issue #207.

This commit is to check required packages in case that the server
administrator does not install eSDK (Extensible SDK) of Yocto.

**Changes proposed in this PR:**
1. Updated a condition to verify required commands
2. Updated annotations

Signed-off-by: Geunsik Lim <leemgs@gmail.com>


---
# [Template] PR Description

In general, github system automatically copies your commit message for your convenience.
Please remove unused part of the template after writing your own PR description with this template.
```bash
$ git commit -s filename1 filename2 ... [enter]

Summarize changes in around 50 characters or less

More detailed explanatory text, if necessary. Wrap it to about 72
characters or so. In some contexts, the first line is treated as the
subject of the commit and the rest of the text as the body. The
blank line separating the summary from the body is critical;
various tools like `log`, `shortlog` and `rebase` can get confused 
if you run the two together.

Further paragraphs come after blank lines.

**Changes proposed in this PR:**
- Bullet points are okay, too
- Typically a hyphen or asterisk is used for the bullet, preceded
  by a single space, with blank lines in between, but conventions vary here.

Resolves: #123
See also: #456, #789

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped

**How to evaluate:**
1. Describe how to evaluate in order to be reproduced by reviewer(s).

Add signed-off message automatically by running **$git commit -s ...** command.

$ git push origin <your_branch_name>
```
