### PR TITLE
config: fixed typos in configuration files

### DIFF
--- a/ci/taos/checker-pr-audit-async.sh
+++ b/ci/taos/checker-pr-audit-async.sh
@@ -312,7 +312,7 @@ do
             ${plugin}-run-queue $arch
         done
     else
-        echo "[DEBUG] Running the $plugin"
+        echo "[DEBUG] run queue: Running the '$plugin' module"
         ${plugin}-run-queue
     fi
 done

--- a/ci/taos/checker-pr-format-async.sh
+++ b/ci/taos/checker-pr-format-async.sh
@@ -170,7 +170,7 @@ source ${REFERENCE_REPOSITORY}/ci/taos/config/config-plugins-format.sh
 
 for plugin in ${format_plugins[*]}
 do
-    echo "[DEBUG] Running the ${plugin}"
+    echo "[DEBUG] run queue: Running the '${plugin}' module"
     ${plugin}
 done
 

--- a/ci/taos/config/config-plugins-audit.sh
+++ b/ci/taos/config/config-plugins-audit.sh
@@ -15,8 +15,8 @@
 #
 
 ##
-# @file config-plugins-audit.sh
-# @brief add plugin modules for a github repository
+# @file     config-plugins-audit.sh
+# @brief    Configuraiton file to maintain audit modules (after completing a build procedure)
 # @see      https://github.com/nnsuite/TAOS-CI
 # @author   Geunsik Lim <geunsik.lim@samsung.com>
 
@@ -24,7 +24,7 @@
 declare -i idx=-1
 
 ###### plugins-base ###############################################################################################
-echo "[MODULE] plugins-base: Plugin group that follow Apache license with good quality"
+echo "[MODULE] plugins-base: Plugin group is a well-maintained collection of plugin modules."
 # Please append your plugin modules here.
 
 audit_plugins[++idx]="pr-audit-build-tizen"
@@ -33,7 +33,6 @@ echo "[DEBUG] ${audit_plugins[idx]} is started."
 echo "[DEBUG] TAOS/${audit_plugins[idx]}: Check if Tizen rpm package is successfully generated."
 echo "[DEBUG] Current path: $(pwd)."
 source ${REFERENCE_REPOSITORY}/ci/taos/plugins-base/${audit_plugins[idx]}.sh
-# Note that do not append the below "$module_name" because build step is implemented as a built-in module partially
 
 
 audit_plugins[++idx]="pr-audit-build-ubuntu"
@@ -42,16 +41,14 @@ echo "[DEBUG] ${audit_plugins[idx]} is started."
 echo "[DEBUG] TAOS/${audit_plugins[idx]}: Check if Ubuntu deb package is successfully generated."
 echo "[DEBUG] Current path: $(pwd)."
 source ${REFERENCE_REPOSITORY}/ci/taos/plugins-base/${audit_plugins[idx]}.sh
-# Note that do not append the below "$module_name" because build step is implemented as a built-in module partially
 
 
 audit_plugins[++idx]="pr-audit-build-yocto"
-echo "[DEBUG] The default BUILD_MODE of ${audit_plugins[idx]} is declared with 99 by default in plugins-base folder."
+echo "[DEBUG] The default BUILD_MODE of ${audit_plugins[idx]} is declared with 99 (SKIP MODE) by default in plugins-base folder."
 echo "[DEBUG] ${audit_plugins[idx]} is started."
 echo "[DEBUG] TAOS/${audit_plugins[idx]}: Check if YOCTO deb package is successfully generated."
 echo "[DEBUG] Current path: $(pwd)."
 source ${REFERENCE_REPOSITORY}/ci/taos/plugins-base/${audit_plugins[idx]}.sh
-# Note that do not append the below "$module_name" because build step is implemented as a built-in module partially
 
 
 

--- a/ci/taos/config/config-plugins-format.sh
+++ b/ci/taos/config/config-plugins-format.sh
@@ -15,8 +15,8 @@
 #
 
 ##
-# @file config-plugins-format.sh
-# @brief add plugin modules for a github repository
+# @file     config-plugins-format.sh
+# @brief    Configuration file to maintain format modules (before doing a build procedure)
 # @see      https://github.com/nnsuite/TAOS-CI
 # @author   Geunsik Lim <geunsik.lim@samsung.com>
 
@@ -31,14 +31,14 @@ echo "[MODULE] plugins-good: Plugin group that follow Apache license with good q
 format_plugins[++idx]="pr-format-doxygen"
 echo "${format_plugins[idx]} is starting."
 echo "[MODULE] TAOS/${format_plugins[idx]}: Check a source code consists of required doxygen tags."
-echo "The current path: $(pwd)."
+echo "[DEBUG] The current path: $(pwd)."
 echo "[DEBUG] source ${REFERENCE_REPOSITORY}/ci/taos/plugins-good/${format_plugins[idx]}.sh"
 source ${REFERENCE_REPOSITORY}/ci/taos/plugins-good/${format_plugins[idx]}.sh
 
 #format_plugins[++idx]="pr-format-indent"
 # echo "${format_plugins[idx]} is starting."
 # echo "[MODULE] TAOS/${format_plugins[idx]}: Check the code formatting style with GNU indent"
-# echo "The current path: $(pwd)."
+# echo "[DEBUG] The current path: $(pwd)."
 # echo "[DEBUG] source ${REFERENCE_REPOSITORY}/ci/taos/plugins-good/${format_plugins[idx]}.sh"
 # source ${REFERENCE_REPOSITORY}/ci/taos/plugins-good/${format_plugins[idx]}.sh
 
@@ -46,90 +46,90 @@ source ${REFERENCE_REPOSITORY}/ci/taos/plugins-good/${format_plugins[idx]}.sh
 #format_plugins[++idx]="pr-format-clang"
 # echo "${format_plugins[idx]} is starting."
 # echo "[MODULE] TAOS/${format_plugins[idx]}: Check the code formatting style with clang-format"
-# echo "The current path: $(pwd)."
+# echo "[DEBUG] The current path: $(pwd)."
 # echo "[DEBUG] source ${REFERENCE_REPOSITORY}/ci/taos/plugins-good/${format_plugins[idx]}.sh"
 # source ${REFERENCE_REPOSITORY}/ci/taos/plugins-good/${format_plugins[idx]}.sh
 
 #format_plugins[++idx]="pr-format-exclusive-vio"
 # echo "${format_plugins[idx]} is starting."
 # echo "[MODULE] TAOS/${format_plugins[idx]}: Check issue #279. VIO commits should not touch non VIO files."
-# echo "The current path: $(pwd)."
+# echo "[DEBUG] The current path: $(pwd)."
 # echo "[DEBUG] source ${REFERENCE_REPOSITORY}/ci/taos/plugins-good/${format_plugins[idx]}.sh"
 # source ${REFERENCE_REPOSITORY}/ci/taos/plugins-good/${format_plugins[idx]}.sh
 
 format_plugins[++idx]="pr-format-pylint"
 echo "${format_plugins[idx]} is starting."
 echo "[MODULE] TAOS/${format_plugins[idx]}: Check the code formatting style with pylint"
-echo "The current path: $(pwd)."
+echo "[DEBUG] The current path: $(pwd)."
 echo "[DEBUG] source ${REFERENCE_REPOSITORY}/ci/taos/plugins-good/${format_plugins[idx]}.sh"
 source ${REFERENCE_REPOSITORY}/ci/taos/plugins-good/${format_plugins[idx]}.sh
 
 format_plugins[++idx]="pr-format-newline"
 echo "${format_plugins[idx]} is starting."
 echo "[MODULE] TAOS/${format_plugins[idx]}: Check if there is a newline issue in text files"
-echo "The current path: $(pwd)."
+echo "[DEBUG] The current path: $(pwd)."
 echo "[DEBUG] source ${REFERENCE_REPOSITORY}/ci/taos/plugins-good/${format_plugins[idx]}.sh"
 source ${REFERENCE_REPOSITORY}/ci/taos/plugins-good/${format_plugins[idx]}.sh
 
 format_plugins[++idx]="pr-format-rpm-spec"
 echo "${format_plugins[idx]} is starting."
 echo "[MODULE] TAOS/${format_plugins[idx]}: Check if there is incorrect staements in *.spec file"
-echo "The current path: $(pwd)."
+echo "[DEBUG] The current path: $(pwd)."
 echo "[DEBUG] source ${REFERENCE_REPOSITORY}/ci/taos/plugins-good/${format_plugins[idx]}.sh"
 source ${REFERENCE_REPOSITORY}/ci/taos/plugins-good/${format_plugins[idx]}.sh
 
 format_plugins[++idx]="pr-format-file-size"
 echo "${format_plugins[idx]} is starting."
 echo "[MODULE] TAOS/${format_plugins[idx]}: Check the file size to not include big binary files"
-echo "The current path: $(pwd)."
+echo "[DEBUG] The current path: $(pwd)."
 echo "[DEBUG] source ${REFERENCE_REPOSITORY}/ci/taos/plugins-good/${format_plugins[idx]}.sh"
 source ${REFERENCE_REPOSITORY}/ci/taos/plugins-good/${format_plugins[idx]}.sh
 
 format_plugins[++idx]="pr-format-cppcheck"
 echo "${format_plugins[idx]} is starting."
-echo "[MODULE] TAOS/${format_plugins[idx]}: Check the file size to not include big binary files"
-echo "The current path: $(pwd)."
+echo "[MODULE] TAOS/${format_plugins[idx]}: Check dangerous coding constructs in source codes (*.c, *.cpp) with cppcheck"
+echo "[DEBUG] The current path: $(pwd)."
 echo "[DEBUG] source ${REFERENCE_REPOSITORY}/ci/taos/plugins-good/${format_plugins[idx]}.sh"
 source ${REFERENCE_REPOSITORY}/ci/taos/plugins-good/${format_plugins[idx]}.sh
 
 format_plugins[++idx]="pr-format-nobody"
 echo "${format_plugins[idx]} is starting."
-echo "[MODULE] TAOS/${format_plugins[idx]}: Check the file size to not include big binary files"
-echo "The current path: $(pwd)."
+echo "[MODULE] TAOS/${format_plugins[idx]}: Check the commit message body"
+echo "[DEBUG] The current path: $(pwd)."
 echo "[DEBUG] source ${REFERENCE_REPOSITORY}/ci/taos/plugins-good/${format_plugins[idx]}.sh"
 source ${REFERENCE_REPOSITORY}/ci/taos/plugins-good/${format_plugins[idx]}.sh
 
 format_plugins[++idx]="pr-format-timestamp"
 echo "${format_plugins[idx]} is starting."
-echo "[MODULE] TAOS/${format_plugins[idx]}: Check the file size to not include big binary files"
-echo "The current path: $(pwd)."
+echo "[MODULE] TAOS/${format_plugins[idx]}: Check the timestamp of the commit"
+echo "[DEBUG] The current path: $(pwd)."
 echo "[DEBUG] source ${REFERENCE_REPOSITORY}/ci/taos/plugins-good/${format_plugins[idx]}.sh"
 source ${REFERENCE_REPOSITORY}/ci/taos/plugins-good/${format_plugins[idx]}.sh
 
 format_plugins[++idx]="pr-format-executable"
 echo "${format_plugins[idx]} is starting."
-echo "[MODULE] TAOS/${format_plugins[idx]}: Check the file size to not include big binary files"
-echo "The current path: $(pwd)."
+echo "[MODULE] TAOS/${format_plugins[idx]}:  Check executable bits for .cpp, .c, .hpp, .h, .prototxt, .caffemodel, .txt., .init"
+echo "[DEBUG] The current path: $(pwd)."
 echo "[DEBUG] source ${REFERENCE_REPOSITORY}/ci/taos/plugins-good/${format_plugins[idx]}.sh"
 source ${REFERENCE_REPOSITORY}/ci/taos/plugins-good/${format_plugins[idx]}.sh
 
-format_plugins[++idx]="pr-hardcoded-path"
+format_plugins[++idx]="pr-format-hardcoded-path"
 echo "${format_plugins[idx]} is starting."
-echo "[MODULE] TAOS/${format_plugins[idx]}: Check the file size to not include big binary files"
-echo "The current path: $(pwd)."
+echo "[MODULE] TAOS/${format_plugins[idx]}: Check prohibited hardcoded paths (/home/* for now)"
+echo "[DEBUG] The current path: $(pwd)."
 echo "[DEBUG] source ${REFERENCE_REPOSITORY}/ci/taos/plugins-good/${format_plugins[idx]}.sh"
 source ${REFERENCE_REPOSITORY}/ci/taos/plugins-good/${format_plugins[idx]}.sh
 
 format_plugins[++idx]="pr-format-misspelling"
 echo "${format_plugins[idx]} is starting."
 echo "[MODULE] TAOS/${format_plugins[idx]}: Check a misspelled statement in a document file with GNU Aspell"
-echo "The current path: $(pwd)."
+echo "[DEBUG] The current path: $(pwd)."
 echo "[DEBUG] source ${REFERENCE_REPOSITORY}/ci/taos/plugins-good/${format_plugins[idx]}.sh"
 source ${REFERENCE_REPOSITORY}/ci/taos/plugins-good/${format_plugins[idx]}.sh
 
 
 
 ##################################################################################################################
-echo "[MODULE] plugins-staging: Plugin group that does not have evaluation and aging test enough"
+echo "[MODULE] plugins-staging: Plugin group that does not have an evaluation and aging test enough"
 # Please append your plugin modules here.
 


### PR DESCRIPTION
It's trivial. This commit is to update the existing annotations in configuration files.
It will be helpful to users that have to enable or disable the existing lots of modules.

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>


---
# [Template] PR Description

In general, github system automatically copies your commit message for your convenience.
Please remove unused part of the template after writing your own PR description with this template.
```bash
$ git commit -s filename1 filename2 ... [enter]

Summarize changes in around 50 characters or less

More detailed explanatory text, if necessary. Wrap it to about 72
characters or so. In some contexts, the first line is treated as the
subject of the commit and the rest of the text as the body. The
blank line separating the summary from the body is critical;
various tools like `log`, `shortlog` and `rebase` can get confused 
if you run the two together.

Further paragraphs come after blank lines.

**Changes proposed in this PR:**
- Bullet points are okay, too
- Typically a hyphen or asterisk is used for the bullet, preceded
  by a single space, with blank lines in between, but conventions vary here.

Resolves: #123
See also: #456, #789

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped

**How to evaluate:**
1. Describe how to evaluate in order to be reproduced by reviewer(s).

Add signed-off message automatically by running **$git commit -s ...** command.

$ git push origin <your_branch_name>
```
