### PR TITLE
module: added debug message to inspece grammar of module

### DIFF
--- a/ci/doc/how-to-use-taos-ci-module.md
+++ b/ci/doc/how-to-use-taos-ci-module.md
@@ -5,5 +5,9 @@ Please append that in `./plugins-{base|good|staging}` folder if you need to deve
    - `plugins-good`: it is a set of plug-ins that we consider to have good quality code, correct functionality, our preferred license (Apache for the plug-in code).
    - `plugins-staging`: it is a set of plug-ins that are not up to par compared to the rest. They might be close to being good quality, but they are missing something - be it a good code review, some documentation, a set of tests, or aging test.
 
+**Note** that you have to verify the grammar of a module that your write newly for your repository as following:
+```bash
+$ bash ./pr-{type}-{module-name}.sh
+```
 ## How to enable new module
 First, open `./config/config-plugins-{format|audit}.sh`. Then, append a function name of a module that you want to attach newly. If you are poor at CI module, we recommend that you refer to the existing examples.

--- a/ci/taos/checker-pr-audit-async.sh
+++ b/ci/taos/checker-pr-audit-async.sh
@@ -56,7 +56,6 @@ source ./config/config-server-administrator.sh
 # Note the "source ./config/config-environment.sh" file can be called in another script
 # instead of in this file in order to support asynchronous operation from cibot.php
 source ./config/config-environment.sh
-source ./common/api_collection.sh
 
 # check if input argument is correct.
 if [[ $1 == "" || $2 == "" || $3 == "" || $4 == "" || $5 == "" || $6 == "" ]]; then
@@ -143,7 +142,7 @@ echo "[MODULE] plugins-base: Plugin group that does have well-maintained feature
 echo "[MODULE] plugins-good: Plugin group that follow Apache license with good quality"
 echo "[MODULE] plugins-staging: Plugin group that does not has evaluation and aging test enough"
 echo "Current path: $(pwd)."
-source ${REFERENCE_REPOSITORY}/ci/taos/config/config-plugins-audit.sh
+source ${REFERENCE_REPOSITORY}/ci/taos/config/config-plugins-audit.sh 2>> ../audit_module_error.log
 echo "[DEBUG] source ${REFERENCE_REPOSITORY}/ci/taos/config/config-plugins-audit.sh"
 
 # create new context name to monitor progress status of a checker

--- a/ci/taos/checker-pr-format-async.sh
+++ b/ci/taos/checker-pr-format-async.sh
@@ -50,7 +50,6 @@ input_delivery_id=$6
 # Note the "source ./config/config-environment.sh" file can be called in another script
 # instead of in this file in order to support asynchronous operation from CI manager
 source ./config/config-environment.sh
-source ./common/api_collection.sh
 
 # check if input argument is correct.
 if [[ $1 == "" || $2 == "" || $3 == "" || $4 == "" || $5 == "" || $6 == "" ]]; then
@@ -166,7 +165,8 @@ echo -e "[MODULE] plugins-staging: Plugin group that does not have evaluation an
 echo -e " "
 echo -e "Current path: $(pwd)."
 echo -e "[DEBUG] source ${REFERENCE_REPOSITORY}/ci/taos/config/config-plugins-format.sh"
-source ${REFERENCE_REPOSITORY}/ci/taos/config/config-plugins-format.sh
+source ${REFERENCE_REPOSITORY}/ci/taos/config/config-plugins-format.sh  2>> ../format_module_error.log
+
 
 for plugin in ${format_plugins[*]}
 do


### PR DESCRIPTION
This commit is to save a debug message for debugging in case that
the grammar of module(s) is not correct while running all modules
(both format and audit modules).

**Changes proposed in this PR:**
1. Added log file to save a debug message in case of incorrect grammar of module.
2. Added documentation

**Case study:**
```bash
$ bash ./pr-format-{module-name}.sh 2> debug.txt ; cat ./debug.txt
line 68: syntax error near unexpected token `fi'
`            fi'
```
Signed-off-by: Geunsik Lim <leemgs@gmail.com>

---
# [Template] PR Description

In general, github system automatically copies your commit message for your convenience.
Please remove unused part of the template after writing your own PR description with this template.
```bash
$ git commit -s filename1 filename2 ... [enter]

Summarize changes in around 50 characters or less

More detailed explanatory text, if necessary. Wrap it to about 72
characters or so. In some contexts, the first line is treated as the
subject of the commit and the rest of the text as the body. The
blank line separating the summary from the body is critical;
various tools like `log`, `shortlog` and `rebase` can get confused 
if you run the two together.

Further paragraphs come after blank lines.

**Changes proposed in this PR:**
- Bullet points are okay, too
- Typically a hyphen or asterisk is used for the bullet, preceded
  by a single space, with blank lines in between, but conventions vary here.

Resolves: #123
See also: #456, #789

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped

**How to evaluate:**
1. Describe how to evaluate in order to be reproduced by reviewer(s).

Add signed-off message automatically by running **$git commit -s ...** command.

$ git push origin <your_branch_name>
```
