### PR TITLE
[Unittest] Make script to auto-generate coverage files.

### DIFF
--- a/ci/gcov/coverage_generator.sh
+++ b/ci/gcov/coverage_generator.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+##
+# Copyright (c) 2018 Samsung Electronics Co., Ltd. All Rights Reserved.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+##
+# @file coverage-generator.sh
+# @brief Auto-generate unit test coverage files
+# @how to append this script to /etc/crontab
+#       $ sudo vi /etc/crontab
+#       30 * * * * www-data /var/www/html/nnstreamer/ci/gcov/coverage-generator.sh
+# @see      https://github.com/nnsuite/TAOS-CI
+# @author   Sewon Oh <sewon.oh@samsung.com>
+# @param    None
+#
+
+# Set-up environements
+dirpath="$( cd "$( dirname "$0")" && pwd )"
+build_root="${dirpath}/../../../"
+
+# Include comman api
+source $dirpath/../taos/common/api_collection.sh
+
+# Check dependency
+check_dependency gbs
+check_dependency rpm2cpio
+check_dependency cpio
+
+# Build unit test coverage rpm
+gbs build -A x86_64 --define "testcoverage 1" -B $dirpath $build_root
+
+# Extract rpm to gcov_html folder
+cp $dirpath/local/repos/tizen/x86_64/RPMS/nnstreamer-unittest-coverage* $dirpath
+pushd $dirpath
+rpm2cpio $dirpath/nnstreamer-unittest-coverage* | cpio -idvm 
+mkdir -p ../gcov_html
+mv -f usr/share/nnstreamer/unittest/result/* ../gcov_html
+popd
+
+# Remove unused folders
+rm -rf $dirpath/local
+rm -rf $dirpath/usr
+

--- a/ci/taos/menu.html
+++ b/ci/taos/menu.html
@@ -43,7 +43,7 @@
         <select size=1 onchange="if(this.value) parent.framebody.location=this.value;" class="mycolor">
             <option value="/" selected>[ PR: details ]</option>
             <option value="./webhook.php">Webhook Handler</option>
-            <option value="../../gcov/">Test Coverage</option>
+            <option value="../../gcov_html/">Code Coverage</option>
             <option value="../repo-workers/?C=M;O=D/">PR: Report Archive</option>
             <option value="../taos/webapp/monitor.php">PR: Running PRs</option>
             <option value="../taos/webapp/top.php">PR: Resource Usage</option>


### PR DESCRIPTION
Using this script, coverage files created at ci/gcov folder.

Fixes issue #126

Signed-off-by: sewon.oh sewon.oh@samsung.com

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped
