### PR TITLE
module: replaced format-doxygen with format-doxygen-tag

### DIFF
--- a/ci/taos/config/config-plugins-format.sh
+++ b/ci/taos/config/config-plugins-format.sh
@@ -28,7 +28,7 @@ declare -i idx=-1
 echo "[MODULE] plugins-good: Plugin group that follow Apache license with good quality"
 # Please append your plugin modules here.
 
-format_plugins[++idx]="pr-format-doxygen"
+format_plugins[++idx]="pr-format-doxygen-tag"
 echo "${format_plugins[idx]} is starting."
 echo "[MODULE] TAOS/${format_plugins[idx]}: Check a source code consists of required doxygen tags."
 echo "[DEBUG] The current path: $(pwd)."

--- a/ci/taos/plugins-good/pr-format-doxygen-tag.sh
+++ b/ci/taos/plugins-good/pr-format-doxygen-tag.sh
@@ -15,11 +15,11 @@
 #
 
 ##
-# @file pr-format-doxygen.sh
+# @file pr-format-doxygen-tag.sh
 # @brief Check if source code includes required doxygen tags
 #
 # This module is to check if a source code appropriately consists of required doxygen tags.
-# The execution result is reported with "TAOS/pr-format-doxygen" context into status section
+# The execution result is reported with "TAOS/pr-format-doxygen-tag" context into status section
 # of a github PR webpage.
 #
 # @see      https://github.com/nnsuite/TAOS-CI
@@ -27,10 +27,10 @@
 # @author   Sewon Oh <sewon.oh@samsung.com>
 
 ##
-# @brief [MODULE] TAOS/pr-format-doxygen
-function pr-format-doxygen(){
+# @brief [MODULE] TAOS/pr-format-doxygen-tag
+function pr-format-doxygen-tag(){
     echo "########################################################################################"
-    echo "[MODULE] TAOS/pr-format-doxygen: Check if source code includes required doxygen tags for doxygen documentation."
+    echo "[MODULE] TAOS/pr-format-doxygen-tag: Check if source code includes required doxygen tags for doxygen documentation."
     # Inspect all *.patch files that are fetched from a commit file
     FILELIST=`git show --pretty="format:" --name-only --diff-filter=AMRC`
     check_result="success"
@@ -177,11 +177,11 @@ function pr-format-doxygen(){
     if [[ $check_result == "success" ]]; then
         echo "[DEBUG] Passed. doxygen documentation."
         message="Successfully source code(s) includes doxygen document correctly."
-        cibot_pr_report $TOKEN "success" "TAOS/pr-format-doxygen" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+        cibot_pr_report $TOKEN "success" "TAOS/pr-format-doxygen-tag" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
     else
         echo "[ERROR] Failed. doxygen documentation."
         message="Oooops. The doxygen checker is failed. Please, write doxygen document in your code."
-        cibot_pr_report $TOKEN "failure" "TAOS/pr-format-doxygen" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+        cibot_pr_report $TOKEN "failure" "TAOS/pr-format-doxygen-tag" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
     
         # inform PR submitter of a hint in more detail
         message=":octocat: **cibot**: $user_id, **$i** does not include doxygen tags such as $doxygen_basic_rules. You must include the doxygen tags in the source code at least."

--- a/ci/taos/test/pr-report.sh
+++ b/ci/taos/test/pr-report.sh
@@ -14,7 +14,7 @@ if [[ $1 == "" ]]; then
 fi
 
 #CONTEXT="TAOS/pr-format-clang"
-#CONTEXT="TAOS/pr-format-doxygen"
+#CONTEXT="TAOS/pr-format-doxygen-tag"
 #CONTEXT="TAOS/pr-format-newline"
 #CONTEXT="TAOS/pr-format-filesize"
 #CONTEXT="TAOS/pr-format-indent"


### PR DESCRIPTION
This commit is to rename the existing doxygen module for readability and maintenance.
* before: pr-format-doxygen
* after : pr-format-doxygen-tag

**Changes proposed in this PR:**
1. replace format-doxygen with format-doxygen-tag

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>


---
# [Template] PR Description

In general, github system automatically copies your commit message for your convenience.
Please remove unused part of the template after writing your own PR description with this template.
```bash
$ git commit -s filename1 filename2 ... [enter]

Summarize changes in around 50 characters or less

More detailed explanatory text, if necessary. Wrap it to about 72
characters or so. In some contexts, the first line is treated as the
subject of the commit and the rest of the text as the body. The
blank line separating the summary from the body is critical;
various tools like `log`, `shortlog` and `rebase` can get confused 
if you run the two together.

Further paragraphs come after blank lines.

**Changes proposed in this PR:**
- Bullet points are okay, too
- Typically a hyphen or asterisk is used for the bullet, preceded
  by a single space, with blank lines in between, but conventions vary here.

Resolves: #123
See also: #456, #789

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped

**How to evaluate:**
1. Describe how to evaluate in order to be reproduced by reviewer(s).

Add signed-off message automatically by running **$git commit -s ...** command.

$ git push origin <your_branch_name>
```
