### PR TITLE
[debug] Added debug message for plugin modules

### DIFF
--- a/ci/taos/checker-pr-audit-async.sh
+++ b/ci/taos/checker-pr-audit-async.sh
@@ -151,14 +151,15 @@ cibot_pr_report $TOKEN "pending" "(INFO)TAOS/pr-audit-all" "$message" "${CISERVE
 
 for plugin in ${audit_plugins[*]}
 do
+    echo -e "[DEBUG] -----------------------------"
     if [[ ${plugin} == "pr-audit-build-tizen" ]]; then
         for arch in $pr_build_arch_type
         do
-            echo "[DEBUG] Job is queued to run 'gbs build -A $arch(for Tizen)' command."
+            echo "[DEBUG] wait queue: Job is queued to run 'gbs build -A $arch (for Tizen)' command."
             ${plugin}-wait-queue $arch
         done
     else
-        echo "[DEBUG] Job is queue to run $plugin"
+        echo "[DEBUG] wait queue: Job is queue to run $plugin"
         ${plugin}-wait-queue
     fi
 done
@@ -281,14 +282,15 @@ cibot_pr_report $TOKEN "pending" "(INFO)TAOS/pr-audit-all" "$message" "${CISERVE
 
 for plugin in ${audit_plugins[*]}
 do
+    echo -e "[DEBUG] -----------------------------"
     if [[ ${plugin} == "pr-audit-build-tizen" ]]; then
         for arch in $pr_build_arch_type
         do
-            echo "[DEBUG] Job is started to run 'gbs build -A $arch(for Tizen)' command."
+            echo "[DEBUG] ready queue: Job is started to run 'gbs build -A $arch (for Tizen)' command."
             ${plugin}-ready-queue $arch
         done
     else
-        echo "[DEBUG] Job is started to run $plugin"
+        echo "[DEBUG] ready queue: Job is started to run $plugin"
         ${plugin}-ready-queue
     fi
 done
@@ -304,10 +306,11 @@ cibot_pr_report $TOKEN "pending" "(INFO)TAOS/pr-audit-all" "$message" "${CISERVE
 
 for plugin in ${audit_plugins[*]}
 do
+    echo -e "-----------------------------"
     if [[ ${plugin} == "pr-audit-build-tizen" ]]; then
         for arch in $pr_build_arch_type
         do
-            echo "[DEBUG] Compiling the source code to Tizen $arch RPM package."
+            echo "[DEBUG] run queue: Compiling the source code to Tizen $arch RPM package."
             ${plugin}-run-queue $arch
         done
     else

--- a/ci/taos/checker-pr-format-async.sh
+++ b/ci/taos/checker-pr-format-async.sh
@@ -170,7 +170,8 @@ source ${REFERENCE_REPOSITORY}/ci/taos/config/config-plugins-format.sh  2>> ../f
 
 for plugin in ${format_plugins[*]}
 do
-    echo "[DEBUG] run queue: Running the '${plugin}' module"
+    echo -e "[DEBUG] -----------------------------"
+    echo -e "[DEBUG] run queue: Running the '${plugin}' module"
     ${plugin}
 done
 


### PR DESCRIPTION
It is a trivial commit. This commit is to append debug messages to monitor
the loding status of plugin modules.

Signed-off-by: Geunsik Lim <leemgs@gmail.com>


---
# [Template] PR Description

In general, github system automatically copies your commit message for your convenience.
Please remove unused part of the template after writing your own PR description with this template.
```bash
$ git commit -s filename1 filename2 ... [enter]

Summarize changes in around 50 characters or less

More detailed explanatory text, if necessary. Wrap it to about 72
characters or so. In some contexts, the first line is treated as the
subject of the commit and the rest of the text as the body. The
blank line separating the summary from the body is critical;
various tools like `log`, `shortlog` and `rebase` can get confused 
if you run the two together.

Further paragraphs come after blank lines.

**Changes proposed in this PR:**
- Bullet points are okay, too
- Typically a hyphen or asterisk is used for the bullet, preceded
  by a single space, with blank lines in between, but conventions vary here.

Resolves: #123
See also: #456, #789

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped

**How to evaluate:**
1. Describe how to evaluate in order to be reproduced by reviewer(s).

Add signed-off message automatically by running **$git commit -s ...** command.

$ git push origin <your_branch_name>
```
