### PR TITLE
[CI-Server] script: improve bash scripts to install required packages

### DIFF
--- a/ci/taos/webapp/install-nnstreamer-packages.sh
+++ b/ci/taos/webapp/install-nnstreamer-packages.sh
@@ -1,30 +1,48 @@
 #!/usr/bin/env bash
 
+
+# Copyright (c) 2018 Samsung Electronics Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 ##
 # @file install-nnstreamer-packages.sh
 # @brief This script is to install packages that are required to run nnstreamer modules.
 #
 # We assume that you use Ubuntu 16.04 x86_64 distribution.
+
+echo -e "########## for CI-server: Setting-up a package repository of TensorFlow"
 # If you do not use Version 16.04, you have to modify /etc/apt/sources.list.d/nnstreamer.list file appropriately. 
-
-
-echo -e "########## Installing base packages for Gstreamer"
-sudo apt -y install libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libglib2.0-dev
-sudo apt -y install gstreamer1.0-tools gstreamer1.0-plugins-base gstreamer1.0-plugins-good
-
-echo -e "########## Installing base packages to test nnstreamer apps"
-sudo apt -y install rpmlint ctags sudo
-sudo apt -y install cmake make
-
-sudo apt -y install python-gi python3-gi
-sudo apt -y install python-gst-1.0 python3-gst-1.0
-sudo apt -y install python-gst-1.0-dbg python3-gst-1.0-dbg
-
-echo -e "########## Setting-up tensorflow build environment"
 sudo apt -y install software-properties-common
-sudo add-apt-repository ppa:nnstreamer/ppa
+yes "" | sudo add-apt-repository ppa:nnstreamer/ppa
 sudo apt -y update
-sudo apt -y install tensorflow-dev tensorflow-lite-dev
 
-echo -e "[DEBUG] Completed...."
+echo -e "########## for CI-server: Installing base packages to check example apps of NNstreamer"
+# fetch a project path from command
+echo -e "[DEBUG] current folder:" $0
+prj_path="`dirname \"$0\"`/../../.."
 
+# go to project path
+pushd $prj_path
+echo -e  "[DEBUG] value of prj_path:" $prj_path
+echo -e  "[DEBUG] current folder:" $(pwd)
+
+# Note that mk-build-deps needs a equivs package.
+sudo apt -y install devscripts equivs > /dev/null
+echo -e "[DEBUG] Installing dependent packages by reading debian/control file."
+sudo mk-build-deps --install debian/control > /dev/null
+popd
+
+echo -e "########## for CI-system: Installing base packages for "
+sudo apt -y install rpmlint ctags sudo
+
+echo -e "[DEBUG] Required packages are successfully installed...."

--- a/ci/taos/webapp/install-packages.sh
+++ b/ci/taos/webapp/install-packages.sh
@@ -19,7 +19,7 @@
 # @dependency apt
 # @see      https://github.com/nnsuite/TAOS-CI
 
-echo -e "########## Installing base packages to set-up taos CI software"
+echo -e "##########  for CI-server: Installing base packages to set-up taos CI software"
 sudo apt -y install bash php curl
 sudo apt -y install apache2
 sudo apt -y install php php-cgi libapache2-mod-php php-common php-pear php-mbstring
@@ -27,17 +27,17 @@ sudo a2enconf php7.0-cgi
 sudo systemctl restart apache2
 
 
-echo -e "########## Installing packages that are required for modules"
+echo -e "########## for CI-system: Installing packages that are required for modules"
 sudo apt -y install  sed ps cat aha git which grep touch find wc cppcheck
 
-echo -e "########## Installing clang-format"
+echo -e "########## for CI-system: Installing clang-format"
 if [[ -f /etc/apt/sources.list.d/clang.list ]]; then
     sudo echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-4.0 main" > /etc/apt/sources.list.d/clang.list
     sudo apt -y update
     sudo apt -y install clang-format-4.0
 fi
 
-echo -e "########## Installing packages for doxygen documentation"
+echo -e "########## for CI-system: Installing packages for doxygen documentation"
 sudo apt -y install doxygen
 sudo apt -y install texlive-latex-base texlive-latex-extra
 sudo apt -y install latex-xcolor
@@ -45,22 +45,22 @@ sudo apt -y install unoconv pdfunite  pdftk
 sudo apt -y install libreoffice
 sudo apt -y install evince
 
-echo -e "########## Setting-up Tizen build environment"
+echo -e "########## for CI-system: Setting-up a build environment of Tizen package (.rpm)"
 if [[ ! -f /etc/apt/sources.list.d/tizen.list ]]; then
     sudo echo "deb [trusted=yes] http://download.tizen.org/tools/latest-release/Ubuntu_16.04/ / # upgraded to xenial" > /etc/apt/sources.list.d/tizen.list
     sudo apt -y update
     sudo apt -y install mic gbs
 fi
 
-echo -e "########## Setting-up Ubuntu build environment"
+echo -e "########## for CI-system: Setting-up a build environment of Ubuntu package (.deb)"
 sudo apt -y install pbuilder debootstrap devscripts
 echo -e "[DEBUG] Note that you have to write ~/.pbuildrc file"
 
 
-echo -e "########## Setting-up Yocto build environment"
+echo -e "########## for CI-system: Setting-up a build environment of Yocto package (.deb)"
 sudo apt -y install gawk wget git-core diffstat unzip texinfo gcc-multilib 
 sudo apt -y install build-essential chrpath socat libsdl1.2-dev xterm
 echo -e "[DEBUG] Note that you have to install Extensible SDK (eSDK) directly"
 
 
-echo -e "[DEBUG] Completed...."
+echo -e "[DEBUG] Required packages are successfully installed...."


### PR DESCRIPTION
This commit is to update the existing scripts in order to install required
packages in the server. After this PR, a 'mk-build-deps' command of the
scripts install automatically dependent packages (e.g., libgtest-dev
package is required by unit test.)

**Changes proposed in this PR:**

* Version 3:
1. Added 'yes' command for auto 'Enter' key while running add-apt-repository
2. Added dirname statement to find debian/control file anywhere

* Version 2:
1. Introduced mk-build-deps command to install dependent packages automatically
2. Indicated a goal: 1) for CI-server, 2) for CI-system for readability and maintenance

* Version 1:
1. Added libgtest-dev in script file.

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>