### PR TITLE
packaging: updated debian/{control,copyright} for lintain & pdebuild

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: taos-ci
 Section: devel
 Priority: optional
 Maintainer: Geunsik Lim <geunsik.lim@samsung.com>
-Build-Depends: debhelper (>=9)
+Build-Depends: cmake, debhelper (>=9)
 Standards-Version: 3.9.6
 Homepage: https://github.com/nnsuite/TAOS-CI
 
@@ -10,8 +10,9 @@ Package: taos-ci
 Architecture: all
 Depends: bash, php, python, curl, ${misc:Depends}
 Description: Automated project coordinator for GitHub repository
-  TAOS-CI is an automated project coordinator to prevent a regression, find bugs,
-  and reduce a nonproductive review process because of incorrect PRs in github.com.
-  Actually, Submitting the incorrect PRs is a PITA in case of continuous integration.
-  Basically, PRs causing regressions will not be automatically merged. As a result
-  of that, it will reduce the burdens of reviewers.
+  TAOS-CI is an automated project coordinator to prevent a regression,
+  find bugs, and reduce a nonproductive review process because of
+  incorrect PRs in github.com.
+  Actually, Submitting the incorrect PRs is a PITA in case of continuous
+  integration. Basically, PRs causing regressions will not be automatically
+  merged. As a result of that, it will reduce the burdens of reviewers.

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,3 +1,18 @@
 Files: *
+Copyright (c) 2018 Samsung Electronics Co., Ltd. All Rights Reserved.
 License: Apache-2.0
-Copyright(C) Samsung Electonics 2018
+
+License: Apache-2.0
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ .
+ On Debian systems, the full text of the Apache License version 2.0
+ can be found in the file
+ '/usr/share/common-licenses/Apache-2.0'.


### PR DESCRIPTION
This commit is to improve the existing debian/* file to fix unexpected
build issues when running pdebuild.

**Changes proposed in this PR:**
1. Added Build-Depends for pdebuild (issue #244)
2. Updated description (within 80 column) to fix lintian warning
3. Changed copyright file
   https://www.debian.org/doc/manuals/maint-guide/dreq.en.html#copyright

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>

---
# [Template] PR Description

In general, github system automatically copies your commit message for your convenience.
Please remove unused part of the template after writing your own PR description with this template.
```bash
$ git commit -s filename1 filename2 ... [enter]

Summarize changes in around 50 characters or less

More detailed explanatory text, if necessary. Wrap it to about 72
characters or so. In some contexts, the first line is treated as the
subject of the commit and the rest of the text as the body. The
blank line separating the summary from the body is critical;
various tools like `log`, `shortlog` and `rebase` can get confused 
if you run the two together.

Further paragraphs come after blank lines.

**Changes proposed in this PR:**
- Bullet points are okay, too
- Typically a hyphen or asterisk is used for the bullet, preceded
  by a single space, with blank lines in between, but conventions vary here.

Resolves: #123
See also: #456, #789

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped

**How to evaluate:**
1. Describe how to evaluate in order to be reproduced by reviewer(s).

Add signed-off message automatically by running **$git commit -s ...** command.

$ git push origin <your_branch_name>
```
