### PR TITLE
webhook: improved secutiry policy

### DIFF
--- a/ci/taos/webhook.php
+++ b/ci/taos/webhook.php
@@ -70,8 +70,8 @@ function json_config(){
     $github_id = $json_config->github->id;
     // Note that you have to use 'print_r' instead of echo function to display decoded json data.
     // print_r ($json_config);
-    printf ("[DEBUG] webhook ID: %s\n<br>", $json_config->github->id);
-    printf ("[DEBUG] webhook secret: %s\n<br>", $json_config->github->secret);
+    printf ("[DEBUG] json config: your webhook ID: %s\n<br>", $json_config->github->id);
+    printf ("[DEBUG] json config: your webhook secret: %s\n<br>", substr_replace("$json_config->github->secret","******",3);
 
     // Please, add "$hookSecret" value in Secret field at https://<github-address>/.../setting/hooks/
     // Set NULL if you want to disable this security.


### PR DESCRIPTION
This commmit is to improve the existing security policy to avoid an unexecpted
security accident. After this PR, we display just two characters from a 'Screct'
value of a json-formatted configuration file.

* before: mywebhookpassword
* after : my******

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>


---
# [Template] PR Description

In general, github system automatically copies your commit message for your convenience.
Please remove unused part of the template after writing your own PR description with this template.
```bash
$ git commit -s filename1 filename2 ... [enter]

Summarize changes in around 50 characters or less

More detailed explanatory text, if necessary. Wrap it to about 72
characters or so. In some contexts, the first line is treated as the
subject of the commit and the rest of the text as the body. The
blank line separating the summary from the body is critical;
various tools like `log`, `shortlog` and `rebase` can get confused 
if you run the two together.

Further paragraphs come after blank lines.

**Changes proposed in this PR:**
- Bullet points are okay, too
- Typically a hyphen or asterisk is used for the bullet, preceded
  by a single space, with blank lines in between, but conventions vary here.

Resolves: #123
See also: #456, #789

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped

**How to evaluate:**
1. Describe how to evaluate in order to be reproduced by reviewer(s).

Add signed-off message automatically by running **$git commit -s ...** command.

$ git push origin <your_branch_name>
```
