### PR TITLE
module: add check level of CPPCheck facility

### DIFF
--- a/ci/taos/config/config-environment.sh
+++ b/ci/taos/config/config-environment.sh
@@ -94,6 +94,12 @@ pr_build_arch_type="x86_64"
 # Advanced = 1 (Basic + "@author, @bug and functions with ctags")
 pr_doxygen_check_level=0
 
+### Check level of CPPCheck:
+# CPPCheck Level 0: The check level is 'err'.
+# CPPCheck Level 1: 'err' + 'warning,performance,unusedFunction'
+pr_cppcheck_check_level=0
+
+
 #### File size limit
 # unit of the file size is MB.
 filesize_limit=5

--- a/ci/taos/plugins-good/pr-format-cppcheck.sh
+++ b/ci/taos/plugins-good/pr-format-cppcheck.sh
@@ -62,7 +62,19 @@ function pr-format-cppcheck(){
                 *.c|*.cpp)
                     echo "[DEBUG] ( $i ) file is source code with the text format."
                     static_analysis_sw="cppcheck"
-                    static_analysis_rules="--enable=warning,performance --std=posix"
+                    if [[ $pr_cppcheck_check_level -eq 0 ]]; then
+                        echo "[DEBUG] cppcheck: It's okay. The value of the cppcheck level is $pr_cppcheck_check_level."
+                        static_analysis_rules="--std=posix"
+                    elif [[ $pr_cppcheck_check_level -eq 1 ]]; then
+                        echo "[DEBUG] cppcheck: It's okay. The value of the cppcheck level is $pr_cppcheck_check_level."
+                        static_analysis_rules="--enable=warning,performance --std=posix"
+                    else
+                        echo "[DEBUG] cppcheck: Oooops. The value of the cppcheck level is $pr_cppcheck_check_level."
+                        echo "[DEBUG] cppcheck: Note that you have to declare one between 0 and 1."
+                        echo "[DEBUG] cppcheck: The module executes an inspection proceudre with level 0."
+                        static_analysis_rules="--std=posix"
+                    fi
+
                     cppcheck_result="cppcheck_result.txt"
                     # Check C/C++ file, enable all checks.
                     $static_analysis_sw $static_analysis_rules $i 2> ../report/$cppcheck_result


### PR DESCRIPTION
Fixes issue #270.
This commit is to append a check level of CPPCheck facility to provide
developers optional levels. It is an appropriate time to support two levels
to CPPcheck facility to avoid a lot of engineering burdens due to a defect report of
SVACE (Commercial software quality tool) at a release time.

* How to change a check level of CPPCheck facility:
  Please modify variables in the config-environment.sh file.

* Proposed levels
CPPCheck Level 0:  (default check is 'err'.)
CPPCheck Level 1:  --enable=warning,performance,unusedFunction
pr_doxygen_check_level=0
pr_doxygen_check_level=1

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>


---
# [Template] PR Description

In general, github system automatically copies your commit message for your convenience.
Please remove unused part of the template after writing your own PR description with this template.
```bash
$ git commit -s filename1 filename2 ... [enter]

Summarize changes in around 50 characters or less

More detailed explanatory text, if necessary. Wrap it to about 72
characters or so. In some contexts, the first line is treated as the
subject of the commit and the rest of the text as the body. The
blank line separating the summary from the body is critical;
various tools like `log`, `shortlog` and `rebase` can get confused 
if you run the two together.

Further paragraphs come after blank lines.

**Changes proposed in this PR:**
- Bullet points are okay, too
- Typically a hyphen or asterisk is used for the bullet, preceded
  by a single space, with blank lines in between, but conventions vary here.

Resolves: #123
See also: #456, #789

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped

**How to evaluate:**
1. Describe how to evaluate in order to be reproduced by reviewer(s).

Add signed-off message automatically by running **$git commit -s ...** command.

$ git push origin <your_branch_name>
```
