### PR TITLE
module: add SLOCCount checker to estimate development cost @open sesame 10/05 15:03

### DIFF
--- a/ci/taos/config/config-plugins-format.sh
+++ b/ci/taos/config/config-plugins-format.sh
@@ -130,6 +130,15 @@ source ${REFERENCE_REPOSITORY}/ci/taos/plugins-good/${format_plugins[idx]}.sh
 format_plugins[++idx]="pr-format-doxygen-build"
 echo "${format_plugins[idx]} is starting."
 echo "[MODULE] TAOS/${format_plugins[idx]}: Check a doxygen grammar if a doxygen can normally generates source code"
+
+format_plugins[++idx]="pr-format-sloccount"
+echo "${format_plugins[idx]} is starting."
+echo "[MODULE] TAOS/${format_plugins[idx]}: Check physical Source Lines of Code (SLOC) in a source code"
+echo "[DEBUG] The current path: $(pwd)."
+echo "[DEBUG] source ${REFERENCE_REPOSITORY}/ci/taos/plugins-good/${format_plugins[idx]}.sh"
+source ${REFERENCE_REPOSITORY}/ci/taos/plugins-good/${format_plugins[idx]}.sh
+
+
 echo "[DEBUG] The current path: $(pwd)."
 echo "[DEBUG] source ${REFERENCE_REPOSITORY}/ci/taos/plugins-good/${format_plugins[idx]}.sh"
 source ${REFERENCE_REPOSITORY}/ci/taos/plugins-good/${format_plugins[idx]}.sh

--- a/ci/taos/plugins-good/pr-format-sloccount.sh
+++ b/ci/taos/plugins-good/pr-format-sloccount.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+
+##
+# Copyright (c) 2018 Samsung Electronics Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+##
+# @file     pr-format-sloccount.sh
+# @brief    Count physical source lines of code (SLOC)
+#
+# It is a set of tools for counting physical Source Lines of Code (SLOC) in a large
+# number of languages of a potentially large set of programs.
+#
+# @see      https://packages.ubuntu.com/search?keywords=sloccount
+# @see      https://github.com/nnsuite/TAOS-CI
+# @author   Geunsik Lim <geunsik.lim@samsung.com>
+#
+
+# @brief [MODULE] TAOS/pr-format-sloccount
+function pr-format-sloccount(){
+echo "########################################################################################"
+echo "[MODULE] TAOS/pr-format-sloccount: Count physical source lines of code (SLOC)"
+pwd
+
+# Check if server administrator install required commands
+check_dependency sloccount
+check_dependency git
+check_dependency file
+
+# Read file names that a contributor modified(e.g., added, moved, deleted, and updated) from a last commit.
+FILELIST=`git show --pretty="format:" --name-only --diff-filter=AMRC`
+
+# Inspect all files that contributor modifed.
+for i in ${FILELIST}; do
+    # default value of check_result is "skip".
+    check_result="skip"
+
+    # skip obsolete folder
+    if [[ $i =~ ^obsolete/.* ]]; then
+        continue
+    fi
+    # skip external folder
+    if [[ $i =~ ^external/.* ]]; then
+        continue
+    fi
+    # Handle only text files in case that there are lots of files in one commit.
+    echo "[DEBUG] file name is ( $i )."
+    if [[ `file $i | grep "ASCII text" | wc -l` -gt 0 ]]; then
+        # Run a SLOCCount module in case that PR includes source codes such as *.c,  *.cpp, *.py.
+        case $i in
+            *.c | *.cpp | *.py)
+                echo "[DEBUG] ( $i ) file is a source code with a ASCII text format."
+                sloc_analysis_sw="sloccount"
+                sloc_analysis_rules="--wide --multiproject"
+                sloc_target_dir=${SRC_PATH}
+                sloc_check_result="sloccount_result.txt"
+
+                # Run this module, then exit from 'for' loop statement to run just once.
+                $sloc_analysis_sw $sloc_analysis_rules $sloc_target_dir > ../report/${sloc_check_result}
+                run_result=$?
+                if [[ $run_result -eq 0 ]]; then
+                    check_result="success"
+                else
+                    check_result="failure"
+                fi
+                break
+                ;;
+            * )
+                echo "[DEBUG] SLOCCount does not check ( $i ) file because it is not a source code."
+                check_result="skip"
+                ;;
+        esac
+    fi
+done
+
+if [[ $check_result == "success" ]]; then
+    echo "[DEBUG] Passed. A sloc check tool - sloccount."
+    message="Successfully source code(s) is analyzed by sloccount command."
+    cibot_pr_report $TOKEN "success" "TAOS/pr-format-sloccount" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+
+elif [[ $check_result == "skip" ]]; then
+    echo "[DEBUG] Skipped. A sloc check tool - sloccount."
+    message="Skipped. Your PR does not include source codes."
+    cibot_pr_report $TOKEN "success" "TAOS/pr-format-sloccount" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+
+else
+    echo "[DEBUG] Failed. A sloc check tool - sloccount."
+    message="Oooops. sloccount checker is failed because the check_result is not either 'success' or 'skip'."
+    cibot_pr_report $TOKEN "failure" "TAOS/pr-format-sloccount" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+
+fi
+
+}


### PR DESCRIPTION
Fixes issue #259.

This commis is to append a set of tools for counting physical Source
Lines of Code (SLOC) in a large number of languages of a potentially
large set of programs.

It summarizes the SLOC results and presents various estimates (such as
effort and cost to develop).

**Changes proposed in this PR:**
1. Added SLOCCount module to estimate the development cost of a project.
2. sloccount statement in config file.

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.co