### PR TITLE
slocc: fixed indentation of slocc module

### DIFF
--- a/ci/taos/plugins-good/pr-format-sloccount.sh
+++ b/ci/taos/plugins-good/pr-format-sloccount.sh
@@ -28,83 +28,83 @@
 
 # @brief [MODULE] TAOS/pr-format-sloccount
 function pr-format-sloccount(){
-echo "########################################################################################"
-echo "[MODULE] TAOS/pr-format-sloccount: Count physical source lines of code (SLOC)"
-pwd
+    echo "########################################################################################"
+    echo "[MODULE] TAOS/pr-format-sloccount: Count physical source lines of code (SLOC)"
+    pwd
 
-# Check if server administrator install required commands
-check_dependency sloccount
-check_dependency git
-check_dependency file
-check_dependency mkdir
-check_dependency grep
+    # Check if server administrator install required commands
+    check_dependency sloccount
+    check_dependency git
+    check_dependency file
+    check_dependency mkdir
+    check_dependency grep
 
-# Read file names that a contributor modified(e.g., added, moved, deleted, and updated) from a last commit.
-FILELIST=`git show --pretty="format:" --name-only --diff-filter=AMRC`
+    # Read file names that a contributor modified(e.g., added, moved, deleted, and updated) from a last commit.
+    FILELIST=`git show --pretty="format:" --name-only --diff-filter=AMRC`
 
-# Inspect all files that contributor modifed.
-for i in ${FILELIST}; do
-    # default value of check_result is "skip".
-    check_result="skip"
+    # Inspect all files that contributor modifed.
+    for i in ${FILELIST}; do
+        # default value of check_result is "skip".
+        check_result="skip"
 
-    # skip obsolete folder
-    if [[ $i =~ ^obsolete/.* ]]; then
-        continue
+        # skip obsolete folder
+        if [[ $i =~ ^obsolete/.* ]]; then
+            continue
+        fi
+        # skip external folder
+        if [[ $i =~ ^external/.* ]]; then
+            continue
+        fi
+        # Handle only text files in case that there are lots of files in one commit.
+        echo "[DEBUG] file name is ( $i )."
+        if [[ `file $i | grep "ASCII text" | wc -l` -gt 0 ]]; then
+            # Run a SLOCCount module in case that a PR includes source codes.
+            case $i in
+                *.c | *.cpp | *.py | *.sh | *.php )
+                    echo "[DEBUG] ( $i ) file is a source code with a ASCII text format."
+                    sloc_analysis_sw="sloccount"
+                    sloc_data_folder="~/.slocdata"
+                    if [[ ! -d $sloc_data_folder ]]; then
+                        mkdir -p $sloc_data_folder
+                    fi
+                    sloc_analysis_rules="--wide --multiproject --datadir $sloc_data_folder"
+                    sloc_target_dir=${SRC_PATH}
+                    sloc_check_result="sloccount_result.txt"
+
+                    # Run this module
+                    $sloc_analysis_sw $sloc_analysis_rules $sloc_target_dir > ../report/${sloc_check_result}
+                    run_result=$?
+                    if [[ $run_result -eq 0 ]]; then
+                        check_result="success"
+                    else
+                        check_result="failure"
+                    fi
+                    # Exit from 'for' loop statement to run just once when a commit includes lots of source code files.
+                    break
+                    ;;
+                * )
+                    echo "[DEBUG] SLOCCount does not check ( $i ) file because it is not a source code."
+                    check_result="skip"
+                    ;;
+            esac
+        fi
+    done
+
+    if [[ $check_result == "success" ]]; then
+        echo "[DEBUG] Passed. A sloc check tool - sloccount."
+        message="Successfully source code(s) is analyzed by sloccount command."
+        cibot_pr_report $TOKEN "success" "TAOS/pr-format-sloccount" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+
+    elif [[ $check_result == "skip" ]]; then
+        echo "[DEBUG] Skipped. A sloc check tool - sloccount."
+        message="Skipped. Your PR does not include source codes."
+        cibot_pr_report $TOKEN "success" "TAOS/pr-format-sloccount" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+
+    else
+        echo "[DEBUG] Failed. A sloc check tool - sloccount."
+        message="Oooops. sloccount checker is failed because the check_result is not either 'success' or 'skip'."
+        cibot_pr_report $TOKEN "failure" "TAOS/pr-format-sloccount" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+
     fi
-    # skip external folder
-    if [[ $i =~ ^external/.* ]]; then
-        continue
-    fi
-    # Handle only text files in case that there are lots of files in one commit.
-    echo "[DEBUG] file name is ( $i )."
-    if [[ `file $i | grep "ASCII text" | wc -l` -gt 0 ]]; then
-        # Run a SLOCCount module in case that a PR includes source codes.
-        case $i in
-            *.c | *.cpp | *.py | *.sh | *.php )
-                echo "[DEBUG] ( $i ) file is a source code with a ASCII text format."
-                sloc_analysis_sw="sloccount"
-                sloc_data_folder="~/.slocdata"
-                if [[ ! -d $sloc_data_folder ]]; then
-                    mkdir -p $sloc_data_folder
-                fi
-                sloc_analysis_rules="--wide --multiproject --datadir $sloc_data_folder"
-                sloc_target_dir=${SRC_PATH}
-                sloc_check_result="sloccount_result.txt"
-
-                # Run this module
-                $sloc_analysis_sw $sloc_analysis_rules $sloc_target_dir > ../report/${sloc_check_result}
-                run_result=$?
-                if [[ $run_result -eq 0 ]]; then
-                    check_result="success"
-                else
-                    check_result="failure"
-                fi
-                # Exit from 'for' loop statement to run just once when a commit includes lots of source code files.
-                break
-                ;;
-            * )
-                echo "[DEBUG] SLOCCount does not check ( $i ) file because it is not a source code."
-                check_result="skip"
-                ;;
-        esac
-    fi
-done
-
-if [[ $check_result == "success" ]]; then
-    echo "[DEBUG] Passed. A sloc check tool - sloccount."
-    message="Successfully source code(s) is analyzed by sloccount command."
-    cibot_pr_report $TOKEN "success" "TAOS/pr-format-sloccount" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
-
-elif [[ $check_result == "skip" ]]; then
-    echo "[DEBUG] Skipped. A sloc check tool - sloccount."
-    message="Skipped. Your PR does not include source codes."
-    cibot_pr_report $TOKEN "success" "TAOS/pr-format-sloccount" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
-
-else
-    echo "[DEBUG] Failed. A sloc check tool - sloccount."
-    message="Oooops. sloccount checker is failed because the check_result is not either 'success' or 'skip'."
-    cibot_pr_report $TOKEN "failure" "TAOS/pr-format-sloccount" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
-
-fi
 
 }


### PR DESCRIPTION
It is trivial. This commit is to fix incorrect indentation of the slocc module.

**Changes proposed in this PR:**
1. Fixed incorrect indentation
2. Removed incorrect white spaces.

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>


---
# [Template] PR Description

In general, github system automatically copies your commit message for your convenience.
Please remove unused part of the template after writing your own PR description with this template.
```bash
$ git commit -s filename1 filename2 ... [enter]

Summarize changes in around 50 characters or less

More detailed explanatory text, if necessary. Wrap it to about 72
characters or so. In some contexts, the first line is treated as the
subject of the commit and the rest of the text as the body. The
blank line separating the summary from the body is critical;
various tools like `log`, `shortlog` and `rebase` can get confused 
if you run the two together.

Further paragraphs come after blank lines.

**Changes proposed in this PR:**
- Bullet points are okay, too
- Typically a hyphen or asterisk is used for the bullet, preceded
  by a single space, with blank lines in between, but conventions vary here.

Resolves: #123
See also: #456, #789

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped

**How to evaluate:**
1. Describe how to evaluate in order to be reproduced by reviewer(s).

Add signed-off message automatically by running **$git commit -s ...** command.

$ git push origin <your_branch_name>
```
