### PR TITLE
API: replaced cibot_pr_report with cibot_report

### DIFF
--- a/ci/doc/how-to-use-taos-ci-module.md
+++ b/ci/doc/how-to-use-taos-ci-module.md
@@ -1,6 +1,6 @@
 
 ## How to develop new module
-Please implement a module in `./plugins-{base|good|staging}` folder if you need to develop new CI module for your own project. We recommend that you use two APIs such as `cibot_comment()` and `cibot_pr_report()` in case that you have to send a webhook message to a GitHub website. You can easily develop new CI module by referencing the existing CI modules because we follow up the Wiki philosophy.
+Please implement a module in `./plugins-{base|good|staging}` folder if you need to develop new CI module for your own project. We recommend that you use two APIs such as `cibot_comment()` and `cibot_report()` in case that you have to send a webhook message to a GitHub website. You can easily develop new CI module by referencing the existing CI modules because we follow up the Wiki philosophy.
    - `plugins-base`: it is a well-maintained collection of CI plugins. A wide rang of Tizen (gbs) and Ubuntu (pdebuild) are included.
    - `plugins-good`: it is a set of plug-ins that we consider to have good quality code, correct functionality, our preferred license (Apache for the plug-in code).
    - `plugins-staging`: it is a set of plug-ins that are not up to par compared to the rest. They might be close to being good quality, but they are missing something - be it a good code review, some documentation, a set of tests, or aging test.

--- a/ci/taos/checker-pr-audit-async.sh
+++ b/ci/taos/checker-pr-audit-async.sh
@@ -147,7 +147,7 @@ echo "[DEBUG] source ${REFERENCE_REPOSITORY}/ci/taos/config/config-plugins-audit
 
 # create new context name to monitor progress status of a checker
 message="Trigger: wait queue. There are other build jobs and we need to wait.. The commit number is $input_commit."
-cibot_pr_report $TOKEN "pending" "(INFO)TAOS/pr-audit-all" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+cibot_report $TOKEN "pending" "(INFO)TAOS/pr-audit-all" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
 
 for plugin in ${audit_plugins[*]}
 do
@@ -278,7 +278,7 @@ done
 # users of current status of a pull request.
 
 message="Trigger: wait queue. The commit number is $input_commit."
-cibot_pr_report $TOKEN "pending" "(INFO)TAOS/pr-audit-all" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+cibot_report $TOKEN "pending" "(INFO)TAOS/pr-audit-all" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
 
 for plugin in ${audit_plugins[*]}
 do
@@ -302,7 +302,7 @@ done
 # if the current status of pull reqeust is building or not.
 
 message="Trigger: run queue. The commit number is $input_commit."
-cibot_pr_report $TOKEN "pending" "(INFO)TAOS/pr-audit-all" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+cibot_report $TOKEN "pending" "(INFO)TAOS/pr-audit-all" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
 
 for plugin in ${audit_plugins[*]}
 do
@@ -368,7 +368,7 @@ echo "send a total report with global_check_result variable. global_check_result
 if [[ $global_check_result == "success" ]]; then
     # The global check is succeeded.
     message="Successfully all audit modules are passed. Commit number is $input_commit."
-    cibot_pr_report $TOKEN "success" "(INFO)TAOS/pr-audit-all" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+    cibot_report $TOKEN "success" "(INFO)TAOS/pr-audit-all" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
 
     # If contributors want later, let's inform developers of CI test result to go to a review process as a final step before merging a PR
     echo "[DEBUG] All audit modules are passed - it is ready to review! :shipit:. Note that CI bot has two sub-bots such as TAOS/pr-audit-all and TAOS/pr-format-all."
@@ -376,11 +376,11 @@ if [[ $global_check_result == "success" ]]; then
 elif [[ $global_check_result == "failure" ]]; then
     # The global check is failed.
     message="Oooops. One of the audits is failed. Resubmit the PR after fixing correctly. Commit number is $input_commit."
-    cibot_pr_report $TOKEN "failure" "(INFO)TAOS/pr-audit-all" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+    cibot_report $TOKEN "failure" "(INFO)TAOS/pr-audit-all" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
 else
     # The global check is failed due to CI error.
     message="CI Error. There is a bug in CI script. Please contact the CI administrator."
-    cibot_pr_report $TOKEN "error" "(INFO)TAOS/pr-audit-all" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+    cibot_report $TOKEN "error" "(INFO)TAOS/pr-audit-all" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
     echo -e "[DEBUG] It seems that this script has a bug. Please check value of \$global_check_result."
 fi
 

--- a/ci/taos/checker-pr-format-async.sh
+++ b/ci/taos/checker-pr-format-async.sh
@@ -106,7 +106,7 @@ cd $dir_ci
 export dir_commit=${dir_worker}/${input_date}-${input_pr}-${input_commit}
 # --------------------------- CI Trigger (queued) --------------------------------------------------------------------
 message="Trigger: queued. The commit number is $input_commit."
-cibot_pr_report $TOKEN "pending" "(INFO)TAOS/pr-format-all" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+cibot_report $TOKEN "pending" "(INFO)TAOS/pr-format-all" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
 
 # --------------------------- git-clone module: clone git repository -------------------------------------------------
 echo -e "[DEBUG] Starting pr-format....\n"
@@ -184,8 +184,8 @@ echo -e "[DEBUG] Varaible global_check_result is $global_check_result."
 if [[ $global_check_result == "success" ]]; then
     # in case of success
     message="Successfully all format checkers are done."
-    cibot_pr_report $TOKEN "success" "(INFO)TAOS/pr-format-all" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
-    echo -e "[DEBUG] cibot_pr_report $TOKEN success (INFO)TAOS/pr-format-all $message ${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/ ${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+    cibot_report $TOKEN "success" "(INFO)TAOS/pr-format-all" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+    echo -e "[DEBUG] cibot_report $TOKEN success (INFO)TAOS/pr-format-all $message ${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/ ${GITHUB_WEBHOOK_API}/statuses/$input_commit"
 
     # inform PR submitter of success content to encourage review process
     echo -e "[DEBUG] (INFO)TAOS/pr-format-all: All format modules are passed - it is ready to review!"
@@ -194,7 +194,7 @@ if [[ $global_check_result == "success" ]]; then
 elif [[ $global_check_result == "failure" ]]; then
     # in case of failure
     message="Oooops. There is a failed format checker. Update your code correctly after reading error messages."
-    cibot_pr_report $TOKEN "failure" "(INFO)TAOS/pr-format-all" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+    cibot_report $TOKEN "failure" "(INFO)TAOS/pr-format-all" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
 
     # inform PR submitter of a hint to fix issues
     message=":octocat: **cibot**: $user_id, One of the format checkers is failed. If you want to get a hint to fix this issue, please go to ${REPOSITORY_WEB}/wiki/."
@@ -203,7 +203,7 @@ elif [[ $global_check_result == "failure" ]]; then
 else
     # in case that CI is broken
     message="Oooops. It seems that CI bot has bug(s). CI bot has to be fixed."
-    cibot_pr_report $TOKEN "failure" "(INFO)TAOS/pr-format-all" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+    cibot_report $TOKEN "failure" "(INFO)TAOS/pr-format-all" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
 
 fi
 

--- a/ci/taos/checker-pr-signed-off-by.sh
+++ b/ci/taos/checker-pr-signed-off-by.sh
@@ -66,7 +66,7 @@ input_result=$3
 
 # --------------------------- CI Trigger ------------------------------------------------------------------------------
 # attach a trigger to TAOS/pr-format-signedoff context.
-cibot_pr_report $TOKEN "pending" "TAOS/pr-format-signedoff" "Triggered. The commit number is $input_commit" "$CISERVER" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+cibot_report $TOKEN "pending" "TAOS/pr-format-signedoff" "Triggered. The commit number is $input_commit" "$CISERVER" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
 
 
  # -------------------------- Report module: submit check result to github-website ----------------------------
@@ -76,11 +76,11 @@ cibot_pr_report $TOKEN "pending" "TAOS/pr-format-signedoff" "Triggered. The comm
 if [[ $input_result == "success" ]]; then
     # in case of success
     message="Successfully signedoff! This PR includes Signed-off-by: string."
-    cibot_pr_report $TOKEN "success" "TAOS/pr-format-signedoff" "$message" "$REPOSITORY_WEB/pull/$input_pr/commits/$input_commit" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+    cibot_report $TOKEN "success" "TAOS/pr-format-signedoff" "$message" "$REPOSITORY_WEB/pull/$input_pr/commits/$input_commit" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
 elif [[ $input_result == "failure" ]]; then
     # in case of failure
     message="Oooops. No signedoff found. This PR does not include 'Signed-off-by:' string. The lawyers tell us we must have it."
-    cibot_pr_report $TOKEN "failure" "TAOS/pr-format-signedoff" "$message" "$REPOSITORY_WEB/pull/$input_pr/commits/$input_commit" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+    cibot_report $TOKEN "failure" "TAOS/pr-format-signedoff" "$message" "$REPOSITORY_WEB/pull/$input_pr/commits/$input_commit" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
 
     # inform contributors of meaning of Signed-off-by: statement
     message="To contributor, We have used '**Signed-off-by:**' notation by default to handle the license issues, that result from contributors. Note that 'Is there a Signed-off-by line?' is important because lawyers tell us we must have to it **to cleanly maintain the open-source license issues** even though it has nothing to do with the code itself."
@@ -88,5 +88,5 @@ elif [[ $input_result == "failure" ]]; then
 else
     # in case of CI error
     message="Oooops. It seems that CI bot includes bug(s). CI bot has to be fixed."
-    cibot_pr_report $TOKEN "error" "TAOS/pr-format-signedoff" "$message" "$REPOSITORY_WEB/pull/$input_pr/commits/$input_commit" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+    cibot_report $TOKEN "error" "TAOS/pr-format-signedoff" "$message" "$REPOSITORY_WEB/pull/$input_pr/commits/$input_commit" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
 fi

--- a/ci/taos/common/api_collection.sh
+++ b/ci/taos/common/api_collection.sh
@@ -56,10 +56,10 @@ function cibot_comment(){
 # arg4: description
 # arg5: target_url
 # arg5: commit address
-function cibot_pr_report(){
+function cibot_report(){
     # check if input argument is correct.
     if [[ $1 == "" || $2 == ""  || $3 == ""  || $4 == ""  || $5 == "" || $6 == "" ]]; then
-        printf "[DEBUG] ERROR: Please, input correct arguments to run cibot_pr_report function.\n"
+        printf "[DEBUG] ERROR: Please, input correct arguments to run cibot_report function.\n"
         exit 1
     fi
     # argeuments

--- a/ci/taos/plugins-base/pr-audit-build-tizen.sh
+++ b/ci/taos/plugins-base/pr-audit-build-tizen.sh
@@ -26,19 +26,19 @@
 # @brief [MODULE] TAOS/pr-audit-build-tizen-wait-queue
 function pr-audit-build-tizen-wait-queue(){
     message="Trigger: wait queue. There are other build jobs and we need to wait.. The commit number is $input_commit."
-    cibot_pr_report $TOKEN "pending" "TAOS/pr-audit-build-tizen-$1" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+    cibot_report $TOKEN "pending" "TAOS/pr-audit-build-tizen-$1" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
 }
 
 # @brief [MODULE] TAOS/pr-audit-build-tizen-ready-queue
 function pr-audit-build-tizen-ready-queue(){
     message="Trigger: ready queue. The commit number is $input_commit."
-    cibot_pr_report $TOKEN "pending" "TAOS/pr-audit-build-tizen-$1" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+    cibot_report $TOKEN "pending" "TAOS/pr-audit-build-tizen-$1" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
 }
 
 # @brief [MODULE] TAOS/pr-audit-build-tizen-run-queue
 function pr-audit-build-tizen-run-queue(){
     message="Trigger: run queue. The commit number is $input_commit."
-    cibot_pr_report $TOKEN "pending" "TAOS/pr-audit-build-tizen-$1" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+    cibot_report $TOKEN "pending" "TAOS/pr-audit-build-tizen-$1" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
 
     echo "[MODULE] TAOS/pr-audit-build-tizen-$1: Check if 'gbs build -A $1' can be successfully passed."
     pwd
@@ -94,10 +94,10 @@ function pr-audit-build-tizen-run-queue(){
         echo -e "[DEBUG] So, we stop remained all tasks at this time."
     
         message="Skipped gbs build -A $1 procedure. No buildable files found. Commit number is $input_commit."
-        cibot_pr_report $TOKEN "success" "TAOS/pr-audit-build-tizen-$1" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+        cibot_report $TOKEN "success" "TAOS/pr-audit-build-tizen-$1" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
     
         message="Skipped gbs build -A $1 procedure. Successfully all audit modules are passed. Commit number is $input_commit."
-        cibot_pr_report $TOKEN "success" "(INFO)TAOS/pr-audit-all" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+        cibot_report $TOKEN "success" "(INFO)TAOS/pr-audit-all" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
     
         echo -e "[DEBUG] All audit modules are passed (gbs build -A $1 procedure is skipped) - it is ready to review!"
     else
@@ -116,10 +116,10 @@ function pr-audit-build-tizen-run-queue(){
         # Let's report build result of source code
         if [[ $check_result == "success" ]]; then
             message="Successfully a build checker is passed. Commit number is '$input_commit'."
-            cibot_pr_report $TOKEN "success" "TAOS/pr-audit-build-tizen-$1" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+            cibot_report $TOKEN "success" "TAOS/pr-audit-build-tizen-$1" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
         else
             message="Oooops. A build checker is failed. Resubmit the PR after fixing correctly. Commit number is $input_commit."
-            cibot_pr_report $TOKEN "failure" "TAOS/pr-audit-build-tizen-$1" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+            cibot_report $TOKEN "failure" "TAOS/pr-audit-build-tizen-$1" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
     
             # comment a hint on failed PR to author.
             message=":octocat: **cibot**: $user_id, A builder checker could not be completed because one of the checkers is not completed. In order to find out a reason, please go to ${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/."

--- a/ci/taos/plugins-base/pr-audit-build-ubuntu.sh
+++ b/ci/taos/plugins-base/pr-audit-build-ubuntu.sh
@@ -37,19 +37,19 @@
 # @brief [MODULE] TAOS/pr-audit-build-ubuntu-wait-queue
 function pr-audit-build-ubuntu-wait-queue(){
     message="Trigger: wait queue. There are other build jobs and we need to wait.. The commit number is $input_commit."
-    cibot_pr_report $TOKEN "pending" "TAOS/pr-audit-build-ubuntu" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+    cibot_report $TOKEN "pending" "TAOS/pr-audit-build-ubuntu" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
 }
 
 # @brief [MODULE] TAOS/pr-audit-build-ubuntu-ready-queue
 function pr-audit-build-ubuntu-ready-queue(){
     message="Trigger: ready queue. The commit number is $input_commit."
-    cibot_pr_report $TOKEN "pending" "TAOS/pr-audit-build-ubuntu" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+    cibot_report $TOKEN "pending" "TAOS/pr-audit-build-ubuntu" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
 }
 
 # @brief [MODULE] TAOS/pr-audit-build-ubuntu-run-queue
 function pr-audit-build-ubuntu-run-queue(){
     message="Trigger: run queue. The commit number is $input_commit."
-    cibot_pr_report $TOKEN "pending" "TAOS/pr-audit-build-ubuntu" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+    cibot_report $TOKEN "pending" "TAOS/pr-audit-build-ubuntu" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
 
     echo "########################################################################################"
     echo "[MODULE] TAOS/pr-audit-build-ubuntu: check build process for Ubuntu distribution"
@@ -124,10 +124,10 @@ function pr-audit-build-ubuntu-run-queue(){
         echo -e "[DEBUG] So, we stop remained all tasks at this time."
 
         message="Skipped pdebuild procedure. No buildable files found. Commit number is $input_commit."
-        cibot_pr_report $TOKEN "success" "TAOS/pr-audit-build-ubuntu" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+        cibot_report $TOKEN "success" "TAOS/pr-audit-build-ubuntu" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
 
         message="Skipped pdebuild procedure. Successfully all audit modules are passed. Commit number is $input_commit."
-        cibot_pr_report $TOKEN "success" "(INFO)TAOS/pr-audit-all" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+        cibot_report $TOKEN "success" "(INFO)TAOS/pr-audit-all" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
 
         echo -e "[DEBUG] pdebuild procedure is skipped - it is ready to review! :shipit: Note that CI bot has two sub-bots such as TAOS/pr-audit-all and TAOS/pr-format-all."
     else
@@ -146,10 +146,10 @@ function pr-audit-build-ubuntu-run-queue(){
         # Let's report build result of source code
         if [[ $check_result == "success" ]]; then
             message="Successfully  Ubuntu build checker is passed. Commit number is '$input_commit'."
-            cibot_pr_report $TOKEN "success" "TAOS/pr-audit-build-ubuntu" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+            cibot_report $TOKEN "success" "TAOS/pr-audit-build-ubuntu" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
         else
             message="Oooops. Ubuntu  build checker is failed. Resubmit the PR after fixing correctly. Commit number is $input_commit."
-            cibot_pr_report $TOKEN "failure" "TAOS/pr-audit-build-ubuntu" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+            cibot_report $TOKEN "failure" "TAOS/pr-audit-build-ubuntu" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
 
             # comment a hint on failed PR to author.
             message=":octocat: **cibot**: $user_id, Oooops. A Ubuntu builder checker could not be completed. To get a hint, please go to ${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/."

--- a/ci/taos/plugins-base/pr-audit-build-yocto.sh
+++ b/ci/taos/plugins-base/pr-audit-build-yocto.sh
@@ -49,19 +49,19 @@
 # @brief [MODULE] TAOS/pr-audit-build-yocto-wait-queue
 function pr-audit-build-yocto-wait-queue(){
     message="Trigger: wait queue. There are other build jobs and we need to wait.. The commit number is $input_commit."
-    cibot_pr_report $TOKEN "pending" "TAOS/pr-audit-build-yocto" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+    cibot_report $TOKEN "pending" "TAOS/pr-audit-build-yocto" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
 }
 
 # @brief [MODULE] TAOS/pr-audit-build-yocto-ready-queue
 function pr-audit-build-yocto-ready-queue(){
     message="Trigger: ready queue. The commit number is $input_commit."
-    cibot_pr_report $TOKEN "pending" "TAOS/pr-audit-build-yocto" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+    cibot_report $TOKEN "pending" "TAOS/pr-audit-build-yocto" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
 }
 
 # @brief [MODULE] TAOS/pr-audit-build-yocto-run-queue
 function pr-audit-build-yocto-run-queue(){
     message="Trigger: run queue. The commit number is $input_commit."
-    cibot_pr_report $TOKEN "pending" "TAOS/pr-audit-build-yocto" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+    cibot_report $TOKEN "pending" "TAOS/pr-audit-build-yocto" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
 
     echo "########################################################################################"
     echo "[MODULE] TAOS/pr-audit-build-yocto: check build process for YOCTO distribution"
@@ -172,10 +172,10 @@ function pr-audit-build-yocto-run-queue(){
         echo -e "[DEBUG] So, we stop remained all tasks at this time."
 
         message="Skipped devtool procedure. No buildable files found. Commit number is $input_commit."
-        cibot_pr_report $TOKEN "success" "TAOS/pr-audit-build-yocto" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+        cibot_report $TOKEN "success" "TAOS/pr-audit-build-yocto" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
 
         message="Skipped devtool procedure. Successfully all audit modules are passed. Commit number is $input_commit."
-        cibot_pr_report $TOKEN "success" "(INFO)TAOS/pr-audit-all" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+        cibot_report $TOKEN "success" "(INFO)TAOS/pr-audit-all" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
 
         echo -e "[DEBUG] devtool procedure is skipped - it is ready to review! :shipit: Note that CI bot has two sub-bots such as TAOS/pr-audit-all and TAOS/pr-format-all."
     elif [[ $YOCTO_ESDK_NAME == "" ]]; then
@@ -185,10 +185,10 @@ function pr-audit-build-yocto-run-queue(){
         echo -e "[DEBUG] So, we stop remained all tasks at this time."
 
         message="Skipped devtool procedure. eSDK is not installed. Commit number is $input_commit."
-        cibot_pr_report $TOKEN "success" "TAOS/pr-audit-build-yocto" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+        cibot_report $TOKEN "success" "TAOS/pr-audit-build-yocto" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
 
         message="Skipped devtool procedure. Successfully all audit modules are passed. Commit number is $input_commit."
-        cibot_pr_report $TOKEN "success" "(INFO)TAOS/pr-audit-all" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+        cibot_report $TOKEN "success" "(INFO)TAOS/pr-audit-all" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
 
         echo -e "[DEBUG] devtool procedure is skipped - it is ready to review! :shipit: Note that CI bot has two sub-bots such as TAOS/pr-audit-all and TAOS/pr-format-all."
     else
@@ -207,10 +207,10 @@ function pr-audit-build-yocto-run-queue(){
         # Let's report build result of source code
         if [[ $check_result == "success" ]]; then
             message="Successfully  YOCTO build checker is passed. Commit number is '$input_commit'."
-            cibot_pr_report $TOKEN "success" "TAOS/pr-audit-build-yocto" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+            cibot_report $TOKEN "success" "TAOS/pr-audit-build-yocto" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
         else
             message="Oooops. YOCTO  build checker is failed. Resubmit the PR after fixing correctly. Commit number is $input_commit."
-            cibot_pr_report $TOKEN "failure" "TAOS/pr-audit-build-yocto" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+            cibot_report $TOKEN "failure" "TAOS/pr-audit-build-yocto" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
 
             # comment a hint on failed PR to author.
             message=":octocat: **cibot**: $user_id, Oooops. A YOCTO builder checker could not be completed. To get a hint, please go to ${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/."

--- a/ci/taos/plugins-good/pr-format-clang.sh
+++ b/ci/taos/plugins-good/pr-format-clang.sh
@@ -79,11 +79,11 @@ function pr-format-clang(){
     if [[ $check_result == "success" ]]; then
         echo "[DEBUG] Passed. A clang-formatting style."
         message="Successfully, The commits are passed."
-        cibot_pr_report $TOKEN "success" "TAOS/pr-format-clang" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+        cibot_report $TOKEN "success" "TAOS/pr-format-clang" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
     else
         echo "[DEBUG] Failed. A clang-formatting style."
         message="Oooops. The component you are submitting with incorrect clang-format style."
-        cibot_pr_report $TOKEN "failure" "TAOS/pr-format-clang" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+        cibot_report $TOKEN "failure" "TAOS/pr-format-clang" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
 fi
 
 

--- a/ci/taos/plugins-good/pr-format-cppcheck.sh
+++ b/ci/taos/plugins-good/pr-format-cppcheck.sh
@@ -107,15 +107,15 @@ function pr-format-cppcheck(){
     if [[ $check_result == "success" ]]; then
         echo "[DEBUG] Passed. static code analysis tool - cppcheck."
         message="Successfully source code(s) is written without dangerous coding constructs."
-        cibot_pr_report $TOKEN "success" "TAOS/pr-format-cppcheck" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+        cibot_report $TOKEN "success" "TAOS/pr-format-cppcheck" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
     elif [[ $check_result == "skip" ]]; then
         echo "[DEBUG] Skipped. static code analysis tool - cppcheck."
         message="Skipped. Your PR does not include c/c++ code(s)."
-        cibot_pr_report $TOKEN "success" "TAOS/pr-format-cppcheck" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+        cibot_report $TOKEN "success" "TAOS/pr-format-cppcheck" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
     else
         echo "[DEBUG] Failed. static code analysis tool - cppcheck."
         message="Oooops. cppcheck is failed. Please, read $cppcheck_result for more details."
-        cibot_pr_report $TOKEN "failure" "TAOS/pr-format-cppcheck" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+        cibot_report $TOKEN "failure" "TAOS/pr-format-cppcheck" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
     
         # inform PR submitter of a hint in more detail
         message=":octocat: **cibot**: $user_id, **$i** includes bug(s). Please fix incorrect coding constructs in your commit before entering a review process."

--- a/ci/taos/plugins-good/pr-format-doxygen-build.sh
+++ b/ci/taos/plugins-good/pr-format-doxygen-build.sh
@@ -96,17 +96,17 @@ done
 if [[ $check_result == "success" ]]; then
     echo -e "[DEBUG] Passed. doxygen build verifier - doxygen."
     message="Successfully source code(s) is written without a incorrect doxygen grammar."
-    cibot_pr_report $TOKEN "success" "TAOS/pr-format-doxygen-build" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+    cibot_report $TOKEN "success" "TAOS/pr-format-doxygen-build" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
 
 elif [[ $check_result == "skip" ]]; then
     echo -e "[DEBUG] Skipped. doxygen build verifier - doxygen."
     message="Skipped. Your PR does not include source code file(s) such as .c and .cpp."
-    cibot_pr_report $TOKEN "success" "TAOS/pr-format-doxygen-build" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+    cibot_report $TOKEN "success" "TAOS/pr-format-doxygen-build" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
 
 else
     echo -e "[DEBUG] Failed. doxygen build verifier - doxygen."
     message="Oooops. doxygen build verifier is failed. Please, read $doxygen_check_result for more details."
-    cibot_pr_report $TOKEN "failure" "TAOS/pr-format-doxygen-build" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+    cibot_report $TOKEN "failure" "TAOS/pr-format-doxygen-build" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
 
     # inform PR submitter of a hint in more detail
     message=":octocat: **cibot**: $user_id, It seems that **$i** includes incorrect doxygen tag(s). Please fix a invalid statement before starting a review process."

--- a/ci/taos/plugins-good/pr-format-doxygen-tag.sh
+++ b/ci/taos/plugins-good/pr-format-doxygen-tag.sh
@@ -188,15 +188,15 @@ function pr-format-doxygen-tag(){
     if [[ $check_result == "success" ]]; then
         echo "[DEBUG] Passed. doxygen documentation."
         message="Successfully source code(s) includes doxygen document correctly."
-        cibot_pr_report $TOKEN "success" "TAOS/pr-format-doxygen-tag" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+        cibot_report $TOKEN "success" "TAOS/pr-format-doxygen-tag" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
     elif [[ $check_result == "skip" ]]; then
         echo "[DEBUG] Skipped. doxygen documentation"
         message="Skipped. Your PR does not include source code(s)."
-        cibot_pr_report $TOKEN "success" "TAOS/pr-format-doxygen-tag" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+        cibot_report $TOKEN "success" "TAOS/pr-format-doxygen-tag" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
     else
         echo "[ERROR] Failed. doxygen documentation."
         message="Oooops. The doxygen checker is failed. Please, write doxygen document in your code."
-        cibot_pr_report $TOKEN "failure" "TAOS/pr-format-doxygen-tag" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+        cibot_report $TOKEN "failure" "TAOS/pr-format-doxygen-tag" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
     
         # inform PR submitter of a hint in more detail
         message=":octocat: **cibot**: $user_id, **$i** does not include doxygen tags such as $doxygen_basic_rules. You must include the doxygen tags in the source code at least."

--- a/ci/taos/plugins-good/pr-format-exclusive-vio.sh
+++ b/ci/taos/plugins-good/pr-format-exclusive-vio.sh
@@ -44,10 +44,10 @@ function pr-format-exclusive-vio(){
         global_check_result="failure"
         echo "[DEBUG] Failed. A VIO commit is not exclusive."
         message="Oooops. This commit has VIO files and non-VIO files at the same time, violating issue #279."
-        cibot_pr_report $TOKEN "failure" "TAOS/pr-format-exclusive-vio" "$message" "$REPOSITORY_WEB/pull/$input_pr/commits/$input_commit" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+        cibot_report $TOKEN "failure" "TAOS/pr-format-exclusive-vio" "$message" "$REPOSITORY_WEB/pull/$input_pr/commits/$input_commit" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
     else
         echo "[DEBUG] Passed. No violation of issue #279."
         message="Successfully, The commits are passed."
-        cibot_pr_report $TOKEN "success" "TAOS/pr-format-exclusive-vio" "$message" "$REPOSITORY_WEB/pull/$input_pr/commits/$input_commit" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+        cibot_report $TOKEN "success" "TAOS/pr-format-exclusive-vio" "$message" "$REPOSITORY_WEB/pull/$input_pr/commits/$input_commit" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
     fi
 }

--- a/ci/taos/plugins-good/pr-format-executable.sh
+++ b/ci/taos/plugins-good/pr-format-executable.sh
@@ -45,11 +45,11 @@ echo "##########################################################################
     if [[ $check_result == "success" ]]; then
         echo "[DEBUG] Passed. A executable bits."
         message="Successfully, The commits are passed."
-        cibot_pr_report $TOKEN "success" "TAOS/pr-format-executable" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+        cibot_report $TOKEN "success" "TAOS/pr-format-executable" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
     else
         echo "[DEBUG] Failed. A executable bits."
         message="Oooops. The commit has an invalid executable file ${X}. Please turn the executable bits off."
-        cibot_pr_report $TOKEN "failure" "TAOS/pr-format-executable" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+        cibot_report $TOKEN "failure" "TAOS/pr-format-executable" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
     
         message=":octocat: **cibot**: $user_id, Oooops. The commit has an invalid executable file. The file is **${X}**. Please turn the executable bits off. Run **chmod 644 file-name** command."
         cibot_comment $TOKEN "$message" "$GITHUB_WEBHOOK_API/issues/$input_pr/comments"

--- a/ci/taos/plugins-good/pr-format-file-size.sh
+++ b/ci/taos/plugins-good/pr-format-file-size.sh
@@ -57,11 +57,11 @@ function pr-format-file-size(){
     if [[ $check_result == "success" ]]; then
         echo "[DEBUG] Passed. File size."
         message="Successfully all files are passed without any issue of file size."
-        cibot_pr_report $TOKEN "success" "TAOS/pr-format-filesize" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+        cibot_report $TOKEN "success" "TAOS/pr-format-filesize" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
     else
         echo "[DEBUG] Failed. File size."
         message="Oooops. File size checker is failed at $i_filename."
-        cibot_pr_report $TOKEN "failure" "TAOS/pr-format-filesize" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+        cibot_report $TOKEN "failure" "TAOS/pr-format-filesize" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
     
         # inform PR submitter of a hint in more detail
         message=":octocat: **cibot**: '$user_id', Oooops. Note that you can not upload a big file that exceeds ${filesize_limit} Mbytes. The file name is ($current_file). The file size is \"$FILESIZE_NUM\". If you have to temporarily upload binary files unavoidably, please share this issue to all members after uploading the files in **/${SKIP_CI_PATHS_FORMAT}** folder."

--- a/ci/taos/plugins-good/pr-format-hardcoded-path.sh
+++ b/ci/taos/plugins-good/pr-format-hardcoded-path.sh
@@ -49,11 +49,11 @@ function pr-format-hardcoded-path(){
     if [[ $check_result == "success" ]]; then
         echo "[DEBUG] Passed. A hardcoded paths."
         message="Successfully, The commits are passed."
-        cibot_pr_report $TOKEN "success" "TAOS/pr-format-hardcoded-path" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+        cibot_report $TOKEN "success" "TAOS/pr-format-hardcoded-path" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
     else
         echo "[DEBUG] Failed. A hardcoded paths."
         message="Oooops. The component you are submitting has hardcoded paths that are not allowed in the source. Please do not hardcode paths."
-        cibot_pr_report $TOKEN "failure" "TAOS/pr-format-hardcoded-path" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+        cibot_report $TOKEN "failure" "TAOS/pr-format-hardcoded-path" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
     fi
 
     

--- a/ci/taos/plugins-good/pr-format-indent.sh
+++ b/ci/taos/plugins-good/pr-format-indent.sh
@@ -73,11 +73,11 @@ function pr-format-indent(){
     if [[ $check_result == "success" ]]; then
         echo "[DEBUG] Passed. A indent formatting style."
         message="Successfully, The commits are passed."
-        cibot_pr_report $TOKEN "success" "TAOS/pr-format-indent" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+        cibot_report $TOKEN "success" "TAOS/pr-format-indent" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
     else
         echo "[DEBUG] Failed. A indent formatting style."
         message="Oooops. The component you are submitting with incorrect indent-format style."
-        cibot_pr_report $TOKEN "failure" "TAOS/pr-format-indent" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+        cibot_report $TOKEN "failure" "TAOS/pr-format-indent" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
     fi
     
 }

--- a/ci/taos/plugins-good/pr-format-misspelling.sh
+++ b/ci/taos/plugins-good/pr-format-misspelling.sh
@@ -94,7 +94,7 @@ done
 if [[ $check_result == "success" ]]; then
     echo "[DEBUG] Passed. A spell check tool - aspell."
     message="Successfully source code(s) is written without a misspelled statement."
-    cibot_pr_report $TOKEN "success" "TAOS/pr-format-misspelling" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+    cibot_report $TOKEN "success" "TAOS/pr-format-misspelling" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
 
     # inform PR submitter of a hint in more detail
     message="**INFO:** You can read if there are misspelled characters at our misspelling check report. Please read ${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/report/${typo_check_result}."
@@ -103,12 +103,12 @@ if [[ $check_result == "success" ]]; then
 elif [[ $check_result == "skip" ]]; then
     echo "[DEBUG] Skipped. A spell check tool - aspell."
     message="Skipped. Your PR does not include document file(s) such as .txt and .md."
-    cibot_pr_report $TOKEN "success" "TAOS/pr-format-misspelling" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+    cibot_report $TOKEN "success" "TAOS/pr-format-misspelling" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
 
 else
     echo "[DEBUG] Failed. A spell check tool - aspell."
     message="Oooops. spelling checker is failed. Please, read $typo_check_result for more details."
-    cibot_pr_report $TOKEN "failure" "TAOS/pr-format-misspelling" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+    cibot_report $TOKEN "failure" "TAOS/pr-format-misspelling" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
 
     # inform PR submitter of a hint in more detail
     message=":octocat: **cibot**: $user_id, It seems that **$i** includes typo(s). Please modify a misspelled statement before starting a review process."

--- a/ci/taos/plugins-good/pr-format-newline.sh
+++ b/ci/taos/plugins-good/pr-format-newline.sh
@@ -66,11 +66,11 @@ function pr-format-newline(){
     if [[ $check_result == "success" ]]; then
         echo -e "[DEBUG] Passed. No newline anomaly."
         message="Successfully all text files are passed without newline issue."
-        cibot_pr_report $TOKEN "success" "TAOS/pr-format-newline" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+        cibot_report $TOKEN "success" "TAOS/pr-format-newline" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
     else
         echo -e "[DEBUG] Failed. A newline anomaly happened."
         message="Oooops. New line checker is failed at $i_filename."
-        cibot_pr_report $TOKEN "failure" "TAOS/pr-format-newline" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+        cibot_report $TOKEN "failure" "TAOS/pr-format-newline" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
     
         # inform PR submitter of a hint in more detail
         message=":octocat: **cibot**: $user_id, There is a newline issue. The final line of a text file should have newline character. Please resubmit your PR after fixing end of line in $current_file."

--- a/ci/taos/plugins-good/pr-format-nobody.sh
+++ b/ci/taos/plugins-good/pr-format-nobody.sh
@@ -73,11 +73,11 @@ function pr-format-nobody(){
     if [[ $check_result == "success" ]]; then
         echo "[DEBUG] Passed. There is no nobody issue."
         message="Successfully commit body includes +5 words."
-        cibot_pr_report $TOKEN "success" "TAOS/pr-format-nobody" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+        cibot_report $TOKEN "success" "TAOS/pr-format-nobody" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
     else
         echo "[DEBUG] Failed. There is no the commit body in this commit."
         message="Oooops. Commit message body checker failed. You must write commit message (+5 words) as well as commit title."
-        cibot_pr_report $TOKEN "failure" "TAOS/pr-format-nobody" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+        cibot_report $TOKEN "failure" "TAOS/pr-format-nobody" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
     fi
 
 }

--- a/ci/taos/plugins-good/pr-format-prohibited-words.sh
+++ b/ci/taos/plugins-good/pr-format-prohibited-words.sh
@@ -107,22 +107,22 @@ function pr-format-prohibited-words(){
     if [[ $check_result == "success" ]]; then
         echo -e "[DEBUG] Passed. A prohibited words tool."
         message="Succeeded. A prohibited words checker is done successfully."
-        cibot_pr_report $TOKEN "success" "TAOS/pr-format-prohibited-words" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+        cibot_report $TOKEN "success" "TAOS/pr-format-prohibited-words" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
 
     elif [[ $check_result == "skip" ]]; then
         echo -e "[DEBUG] Skipped. A prohibited words tool."
         message="Skipped. Your PR does not include a text file."
-        cibot_pr_report $TOKEN "success" "TAOS/pr-format-prohibited-words" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+        cibot_report $TOKEN "success" "TAOS/pr-format-prohibited-words" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
 
     elif [[ $check_result == "failure" ]]; then
         echo -e "[DEBUG] Failed. A prohibited words tool."
         message="Failed. Your PR includes one of the prohibited words at least."
-        cibot_pr_report $TOKEN "failure" "TAOS/pr-format-prohibited-words" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+        cibot_report $TOKEN "failure" "TAOS/pr-format-prohibited-words" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
 
     else
         echo -e "[DEBUG] Unexpected Error. A prohibited words tool."
         message="Oooops. It seems that a prohibited words checker has a bug."
-        cibot_pr_report $TOKEN "failure" "TAOS/pr-format-prohibited-words" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+        cibot_report $TOKEN "failure" "TAOS/pr-format-prohibited-words" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
 
     fi
 

--- a/ci/taos/plugins-good/pr-format-pylint.sh
+++ b/ci/taos/plugins-good/pr-format-pylint.sh
@@ -76,7 +76,7 @@ done
 if [[ $check_result == "success" ]]; then
     echo "[DEBUG] Passed. static code analysis tool - pylint."
     message="Successfully source code(s) is written without dangerous coding constructs."
-    cibot_pr_report $TOKEN "success" "TAOS/pr-format-pylint" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+    cibot_report $TOKEN "success" "TAOS/pr-format-pylint" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
 
     # inform PR submitter of a hint in more detail
     message="We generate a report if there are dangerous coding constructs in your code. Please read ${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/report/${py_check_result}."
@@ -85,12 +85,12 @@ if [[ $check_result == "success" ]]; then
 elif [[ $check_result == "skip" ]]; then
     echo "[DEBUG] Skipped. static code analysis tool - pylint."
     message="Skipped. Your PR does not include python code(s)."
-    cibot_pr_report $TOKEN "success" "TAOS/pr-format-pylint" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+    cibot_report $TOKEN "success" "TAOS/pr-format-pylint" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
 
 else
     echo "[DEBUG] Failed. static code analysis tool - pylint."
     message="Oooops. cppcheck is failed. Please, read $py_check_result for more details."
-    cibot_pr_report $TOKEN "failure" "TAOS/pr-format-pylint" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+    cibot_report $TOKEN "failure" "TAOS/pr-format-pylint" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
 
     # inform PR submitter of a hint in more detail
     message=":octocat: **cibot**: $user_id, It seems that **$i** includes bug(s). You must fix incorrect coding constructs in the source code before entering a review process."

--- a/ci/taos/plugins-good/pr-format-rpm-spec.sh
+++ b/ci/taos/plugins-good/pr-format-rpm-spec.sh
@@ -71,16 +71,16 @@ function pr-format-rpm-spec(){
         if [[ $check_result == "success" ]]; then
             echo "[DEBUG] Passed. the rpm spec checker."
             message="Successfully rpm spec checker is done."
-            cibot_pr_report $TOKEN "success" "TAOS/pr-format-rpm-spec" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+            cibot_report $TOKEN "success" "TAOS/pr-format-rpm-spec" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
         else
             echo "[DEBUG] Failed. the rpm spec checker."
             message="Oooops. The rpm spec checker is failed."
-            cibot_pr_report $TOKEN "failure" "TAOS/pr-format-rpm-spec" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+            cibot_report $TOKEN "failure" "TAOS/pr-format-rpm-spec" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
         fi
     else
         echo "[DEBUG] Skipped. the rpm spec checker."
         message="Skipped. rpm spec checker is jumped because you did not modify a spec file."
-        cibot_pr_report $TOKEN "success" "TAOS/pr-format-rpm-spec" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+        cibot_report $TOKEN "success" "TAOS/pr-format-rpm-spec" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
     
     fi
 }

--- a/ci/taos/plugins-good/pr-format-sloccount.sh
+++ b/ci/taos/plugins-good/pr-format-sloccount.sh
@@ -93,17 +93,17 @@ function pr-format-sloccount(){
     if [[ $check_result == "success" ]]; then
         echo "[DEBUG] Passed. A sloc check tool - sloccount."
         message="Successfully source code(s) is analyzed by sloccount command."
-        cibot_pr_report $TOKEN "success" "TAOS/pr-format-sloccount" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+        cibot_report $TOKEN "success" "TAOS/pr-format-sloccount" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
 
     elif [[ $check_result == "skip" ]]; then
         echo "[DEBUG] Skipped. A sloc check tool - sloccount."
         message="Skipped. Your PR does not include source codes."
-        cibot_pr_report $TOKEN "success" "TAOS/pr-format-sloccount" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+        cibot_report $TOKEN "success" "TAOS/pr-format-sloccount" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
 
     else
         echo "[DEBUG] Failed. A sloc check tool - sloccount."
         message="Oooops. sloccount checker is failed because the check_result is not either 'success' or 'skip'."
-        cibot_pr_report $TOKEN "failure" "TAOS/pr-format-sloccount" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+        cibot_report $TOKEN "failure" "TAOS/pr-format-sloccount" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
 
     fi
 

--- a/ci/taos/plugins-good/pr-format-timestamp.sh
+++ b/ci/taos/plugins-good/pr-format-timestamp.sh
@@ -46,11 +46,11 @@ fi
 if [[ $check_result == "success" ]]; then
     echo "[DEBUG] Passed. A timestamp."
     message="Successfully the commit has no timestamp error."
-    cibot_pr_report $TOKEN "success" "TAOS/pr-format-timestamp" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+    cibot_report $TOKEN "success" "TAOS/pr-format-timestamp" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
 else
     echo "[DEBUG] Failed. A timestamp."
     message="Timestamp error: files are from the future: ${TIMESTAMP_READ} > (now) ${NOW_READ}."
-    cibot_pr_report $TOKEN "failure" "TAOS/pr-format-timestamp" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+    cibot_report $TOKEN "failure" "TAOS/pr-format-timestamp" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
 fi
 
 

--- a/ci/taos/plugins-staging/pr-audit-resource.sh
+++ b/ci/taos/plugins-staging/pr-audit-resource.sh
@@ -71,10 +71,10 @@ function pr-audit-resource(){
     echo "report the execution result of resource checker. check_result is ${check_result}. "
     if [[ $check_result == "success" ]]; then
         message="Successfully Resource checker is passed. Commit number is '$input_commit'."
-        cibot_pr_report $TOKEN "success" "TAOS/pr-audit-resource" "$message" "$REPOSITORY_WEB/pull/$input_pr/commits/$input_commit" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+        cibot_report $TOKEN "success" "TAOS/pr-audit-resource" "$message" "$REPOSITORY_WEB/pull/$input_pr/commits/$input_commit" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
     else
         message="Oooops. Resource checker is failed. Resubmit the PR after fixing correctly. Commit number is $input_commit."
-        cibot_pr_report $TOKEN "failure" "TAOS/pr-audit-resource" "$message" "$REPOSITORY_WEB/pull/$input_pr/commits/$input_commit" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+        cibot_report $TOKEN "failure" "TAOS/pr-audit-resource" "$message" "$REPOSITORY_WEB/pull/$input_pr/commits/$input_commit" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
     
         # comment a hint on failed PR to author.
         message=":octocat: **cibot**: $user_id, Resource checker could not be completed because not-installed resources exist. To find out the reasons, please go to ${CISERVER}/${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/report/resource_check_${input_pr}_error.txt."

--- a/ci/taos/plugins-staging/pr-nnstreamer-ubuntu-apptest.sh
+++ b/ci/taos/plugins-staging/pr-nnstreamer-ubuntu-apptest.sh
@@ -32,21 +32,21 @@
 function pr-nnstreamer-ubuntu-apptest-wait-queue(){
     echo -e "[DEBUG] Waiting CI trigger to run nnstreamer sample app actually."
     message="Trigger: wait queue. There are other build jobs and we need to wait.. The commit number is $input_commit."
-    cibot_pr_report $TOKEN "pending" "TAOS/pr-nnstreamer-apptest" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+    cibot_report $TOKEN "pending" "TAOS/pr-nnstreamer-apptest" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
 }
 
 # @brief [MODULE] TAOS/pr-nnstreamer-ubuntu-apptest-ready-queue
 function pr-nnstreamer-ubuntu-apptest-ready-queue(){
     echo -e "[DEBUG] Readying CI trigger to run nnstreamer sample app actually."
     message="Trigger: ready queue. The commit number is $input_commit."
-    cibot_pr_report $TOKEN "pending" "TAOS/pr-nnstreamer-apptest" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+    cibot_report $TOKEN "pending" "TAOS/pr-nnstreamer-apptest" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
 }
 
 # @brief [MODULE] TAOS/pr-nnstreamer-ubuntu-apptest-run-queue
 function pr-nnstreamer-ubuntu-apptest-run-queue() {
     echo -e "[DEBUG] Starting CI trigger to run nnstreamer sample app actually."
     message="Trigger: run queue. The commit number is $input_commit."
-    cibot_pr_report $TOKEN "pending" "TAOS/pr-nnstreamer-apptest" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+    cibot_report $TOKEN "pending" "TAOS/pr-nnstreamer-apptest" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
 
     echo -e "########################################################################################"
     echo -e "[MODULE] TAOS/pr-nnstreamer-apptest: Starting sample app test"
@@ -111,7 +111,7 @@ function pr-nnstreamer-ubuntu-apptest-run-queue() {
         global_check_result="failure"
 
         message="Oooops. apptest is failed. Resubmit the PR after fixing correctly. Commit number is $input_commit."
-        cibot_pr_report $TOKEN "failure" "TAOS/pr-nnstreamer-apptest" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+        cibot_report $TOKEN "failure" "TAOS/pr-nnstreamer-apptest" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
     
         # comment a hint on failed PR to author.
         message=":octocat: **cibot**: $user_id, apptest could not be completed. To find out the reasons, please go to ${CISERVER}/${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/checker-pr-audit.log"
@@ -207,10 +207,10 @@ function pr-nnstreamer-ubuntu-apptest-run-queue() {
     echo -e "[DEBUG] report the execution result of apptest. result is ${result}. "
     if [[ $check_result == "success" ]]; then
         message="Successfully apptest is passed. Commit number is '$input_commit'."
-        cibot_pr_report $TOKEN "success" "TAOS/pr-nnstreamer-apptest" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+        cibot_report $TOKEN "success" "TAOS/pr-nnstreamer-apptest" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
     else
         message="Oooops. apptest is failed. Resubmit the PR after fixing correctly. Commit number is $input_commit."
-        cibot_pr_report $TOKEN "failure" "TAOS/pr-nnstreamer-apptest" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+        cibot_report $TOKEN "failure" "TAOS/pr-nnstreamer-apptest" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
     
         # comment a hint on failed PR to author.
         message=":octocat: **cibot**: $user_id, apptest could not be completed. To find out the reasons, please go to ${CISERVER}/${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/checker-pr-audit.log"


### PR DESCRIPTION
Fixes issue #289.

This commit is to rename the existing API name of the CI bot to improve a readability of the APIs.
* Before: cibot_pr_report()
* After : cibot_report()

**Changes proposed in this PR:**
1. Rename the existing webhook API

Signed-off-by: Geunsik Lim <leemgs@gmail.com>
Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>


---
