### PR TITLE
Plugin: fixed count issue of prohibited words checker

### DIFF
--- a/ci/taos/config/prohibited_words.txt
+++ b/ci/taos/config/prohibited_words.txt
@@ -1,3 +1,3 @@
 samsung.net
 FUCK
-
+file

--- a/ci/taos/plugins-good/pr-format-prohibited-words.sh
+++ b/ci/taos/plugins-good/pr-format-prohibited-words.sh
@@ -81,14 +81,13 @@ function pr-format-prohibited-words(){
 
         # Step 1: Run this module to filter prohibited words from a text file.
         # (e.g., grep --color -f "$PROHIBITED_WORDS" $filename)
-        result_content=$($bad_words_sw $bad_words_rules $target_files)
+        $bad_words_sw $bad_words_rules $target_files > ../report/${bad_word_log_file}
 
-        # Step 2: Save a log file for debugging in case of a failure
-        echo -e "$result_content"
-        echo -e "$result_content" > ../report/${bad_words_log_file}
+        # Step 2: Display the execution result for debugging in case of a failure
+        cat ../report/${bad_words_log_file}
 
         # Step 3: Count prohibited words from variable result_content
-        result_count=$(echo -e "$result_content" | grep -c '^' )
+        result_count=$(cat ../report/${bad_word_log_file} | grep -c '^' )
 
         # Step 4: change a value of the check result
         if [[ $result_count -gt 0 ]]; then
@@ -115,9 +114,14 @@ function pr-format-prohibited-words(){
         message="Skipped. Your PR does not include a text file."
         cibot_pr_report $TOKEN "success" "TAOS/pr-format-prohibited-words" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
 
-    else
+    elif [[ $check_result == "failure" ]]; then
         echo -e "[DEBUG] Failed. A prohibited words tool."
-        message="Oooops. A prohibited words checker is failed because the check_result is not either 'success' or 'skip'."
+        message="Failed. Your PR includes one of the prohibited words at least."
+        cibot_pr_report $TOKEN "failure" "TAOS/pr-format-prohibited-words" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+
+    else
+        echo -e "[DEBUG] Unexpected Error. A prohibited words tool."
+        message="Oooops. It seems that a prohibited words checker has a bug."
         cibot_pr_report $TOKEN "failure" "TAOS/pr-format-prohibited-words" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
 
     fi


### PR DESCRIPTION
This commit is to fix an incorrect count calculation of prohibited words checker
when a soue code files of a commit includes specified prohibited words.

**Changes proposed in this PR:**
1. Fixed incorrect count result when use $(....) statement of bash
2. Updated a report mode (e.g., success, failure, skip, and unexpected error).

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>


---
# [Template] PR Description

In general, github system automatically copies your commit message for your convenience.
Please remove unused part of the template after writing your own PR description with this template.
```bash
$ git commit -s filename1 filename2 ... [enter]

Summarize changes in around 50 characters or less

More detailed explanatory text, if necessary. Wrap it to about 72
characters or so. In some contexts, the first line is treated as the
subject of the commit and the rest of the text as the body. The
blank line separating the summary from the body is critical;
various tools like `log`, `shortlog` and `rebase` can get confused 
if you run the two together.

Further paragraphs come after blank lines.

**Changes proposed in this PR:**
- Bullet points are okay, too
- Typically a hyphen or asterisk is used for the bullet, preceded
  by a single space, with blank lines in between, but conventions vary here.

Resolves: #123
See also: #456, #789

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped

**How to evaluate:**
1. Describe how to evaluate in order to be reproduced by reviewer(s).

Add signed-off message automatically by running **$git commit -s ...** command.

$ git push origin <your_branch_name>
```
