### PR TITLE
Urgent: [module] prohibited-words: fixed typo of log file

### DIFF
--- a/ci/taos/plugins-good/pr-format-prohibited-words.sh
+++ b/ci/taos/plugins-good/pr-format-prohibited-words.sh
@@ -81,7 +81,7 @@ function pr-format-prohibited-words(){
 
         # Step 1: Run this module to filter prohibited words from a text file.
         # (e.g., grep --color -f "$PROHIBITED_WORDS" $filename)
-        $bad_words_sw $bad_words_rules $target_files > ../report/${bad_word_log_file}
+        $bad_words_sw $bad_words_rules $target_files > ../report/${bad_words_log_file}
 
         # Step 2: Display the execution result for debugging in case of a failure
         cat ../report/${bad_words_log_file}


### PR DESCRIPTION
This commit is to fix a typo of log file name in the
prohibited words checker.

Signed-off-by: Geunsik Lim <leemgs@gmail.com>


---
# [Template] PR Description

In general, github system automatically copies your commit message for your convenience.
Please remove unused part of the template after writing your own PR description with this template.
```bash
$ git commit -s filename1 filename2 ... [enter]

Summarize changes in around 50 characters or less

More detailed explanatory text, if necessary. Wrap it to about 72
characters or so. In some contexts, the first line is treated as the
subject of the commit and the rest of the text as the body. The
blank line separating the summary from the body is critical;
various tools like `log`, `shortlog` and `rebase` can get confused 
if you run the two together.

Further paragraphs come after blank lines.

**Changes proposed in this PR:**
- Bullet points are okay, too
- Typically a hyphen or asterisk is used for the bullet, preceded
  by a single space, with blank lines in between, but conventions vary here.

Resolves: #123
See also: #456, #789

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped

**How to evaluate:**
1. Describe how to evaluate in order to be reproduced by reviewer(s).

Add signed-off message automatically by running **$git commit -s ...** command.

$ git push origin <your_branch_name>
```
