### PR TITLE
module: fix security issue of /dev/video* in NNStreamer apptest

### DIFF
--- a/ci/taos/plugins-staging/pr-audit-nnstreamer-ubuntu-apptest.sh
+++ b/ci/taos/plugins-staging/pr-audit-nnstreamer-ubuntu-apptest.sh
@@ -53,6 +53,9 @@ function pr-audit-nnstreamer-ubuntu-apptest-run-queue() {
     check_dependency Xvnc
     check_dependency git
     check_dependency insmod
+    check_dependency cat
+    check_dependency grep
+    check_dependency usermod
 
     # Set-up environment variables.
     export NNST_ROOT="${dir_ci}/${dir_commit}/${PRJ_REPO_OWNER}"
@@ -140,10 +143,13 @@ function pr-audit-nnstreamer-ubuntu-apptest-run-queue() {
         sudo insmod /lib/modules/`uname -r`/kernel/drivers/media/media.ko
         sudo insmod /lib/modules/`uname -r`/kernel/drivers/media/v4l2-core/videodev.ko
         sudo insmod ./v4l2loopback.ko
-        pushd /dev
-        sudo chmod 777 video0
-        # Leave '/dev' directory
-        popd
+
+        # Note that the server administrator must add 'www-data' (webapp id) account to 'video' group to access /dev/video*
+        # Do not use '777' permission  to avoid a security vulnerability
+        sudo usermod -a -G video www-data
+        echo -e "[DEBUG] The group account 'video' includes the below user accounts:"
+        cat /etc/group | grep video
+
         # Leave '${REFERENCE_REPOSITORY}/v4l2loopback' directory
         popd    
         


### PR DESCRIPTION
Fixed the issue 651 (https://github.com/nnsuite/nnstreamer/issues/651).

This commit is to fix a potential security issue of /dev/video* in NNStreamer
apptest module.

 Note that the server administrator must add 'www-data' (webapp id) account to
'video' group to access /dev/video*. Do not use '777' permission  to avoid a
security vulnerability.

**Changes proposed in this PR:**
1. Improved access method of /dev/video* (device node file)
2. Added dependent commands

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>


---
# [Template] PR Description

In general, github system automatically copies your commit message for your convenience.
Please remove unused part of the template after writing your own PR description with this template.
```bash
$ git commit -s filename1 filename2 ... [enter]

Summarize changes in around 50 characters or less

More detailed explanatory text, if necessary. Wrap it to about 72
characters or so. In some contexts, the first line is treated as the
subject of the commit and the rest of the text as the body. The
blank line separating the summary from the body is critical;
various tools like `log`, `shortlog` and `rebase` can get confused 
if you run the two together.

Further paragraphs come after blank lines.

**Changes proposed in this PR:**
- Bullet points are okay, too
- Typically a hyphen or asterisk is used for the bullet, preceded
  by a single space, with blank lines in between, but conventions vary here.

Resolves: #123
See also: #456, #789

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped

**How to evaluate:**
1. Describe how to evaluate in order to be reproduced by reviewer(s).

Add signed-off message automatically by running **$git commit -s ...** command.

$ git push origin <your_branch_name>
```
