### PR TITLE
Webhook handler: Unified two checkers (format and audit) @open sesame 10/16 19:09

### DIFF
--- a/ci/taos/checker-pr-gateway.sh
+++ b/ci/taos/checker-pr-gateway.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+##
+# Copyright (c) 2018 Samsung Electronics Co., Ltd. All Rights Reserved.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+##
+# @file     checker-pr-gateway.sh
+# @brief    It clones a github repository with "git clone" command  whenever a PR is submitted.
+# @see      https://github.com/nnsuite/TAOS-CI
+# @author   Geunsik Lim <geunsik.lim@samsung.com>
+# @param arguments are received from CI manager
+#  arg1: date(Ymdhms)
+#  arg2: commit number
+#  arg3: repository address of PR
+#  arg4: branch name
+#  arg5: PR number
+#  arg6: delivery id
+#
+# @see variables to control the directories
+#  $dir_ci directory is CI folder
+#  $dir_worker   directory is PR worker folder
+#  $dir_commit   directory is commit folder
+#
+# Arguments
+date=$1
+commit=$2
+repo=$3
+branch=$4
+pr_no=$5
+delivery_id=$6
+
+result=0
+cmd="./checker-pr-format.sh $date $commit $repo $branch $pr_no $delivery_id > /dev/null 2>/dev/null &"
+$cmd
+result=$?
+echo -e "[DEBUG] checker: checker-pr-format.sh is done asynchronously. The variable result is $result."
+echo -e "[DEBUG] It means that checker-pr-format.sh is still running now."
+echo -e "[DEBUG] ./checker-pr-format.sh $date $commit $repo $branch $pr_no $delivery_id"
+
+result=0
+cmd="./checker-pr-audit.sh $date $commit $repo $branch $pr_no $delivery_id > /dev/null 2>/dev/null &"
+$cmd
+result=$?
+echo -e "[DEBUG] checker: checker-pr-audit.sh is done asynchronously. The variable result is $result."
+echo -e "[DEBUG] It means that checker-pr-audit.sh is still running now."
+echo -e "[DEBUG] ./checker-pr-audit.sh $date $commit $repo $branch $pr_no $delivery_id"

--- a/ci/taos/webhook.php
+++ b/ci/taos/webhook.php
@@ -258,11 +258,11 @@ function github_event_handling(){
             printf ("\n\n");
             check_open_sesame();
 
-            // Checker: checker-pr-format.sh
+            // Checker: checker-pr-gateway.sh
             if ($payload->action == "opened" || ($payload->action == "edited" && $open_sesame == "true")||
                 $payload->action == "synchronize"){
                 printf ("\n\n");
-                printf ("[DEBUG] #### checker: starting ./checker-pr-format.sh ...)\n");
+                printf ("[DEBUG] #### checker: starting ./checker-pr-gateway.sh ...)\n");
                 echo ("[DEBUG] action: '$payload->action'. \n");
                 $date=date_time_us();
                 $commit = $payload->pull_request->head->sha;
@@ -272,55 +272,26 @@ function github_event_handling(){
                 $pr_no=$payload->pull_request->number;
                 $delivery_id = $_SERVER['HTTP_X_GITHUB_DELIVERY'];
                 printf ("[DEBUG] current PR number: $pr_no \n");
-                printf ("[DEBUG] checker-pr-format.sh - arg1) date: $date \n");
-                printf ("[DEBUG] checker-pr-format.sh - arg2) commit: $commit \n");
-                printf ("[DEBUG] checker-pr-format.sh - arg3) repo: $repo \n");
-                printf ("[DEBUG] checker-pr-format.sh - arg4) branch: $branch \n");
-                printf ("[DEBUG] checker-pr-format.sh - arg5) pr no: $pr_no \n");
-                printf ("[DEBUG] checker-pr-format.sh - arg6) X-GitHub-Delivery: $delivery_id \n");
-                $result=0;
-                // Run a script asynchronously to avoid service timeout generated due to long build time.
+                printf ("[DEBUG] arg1) date: $date \n");
+                printf ("[DEBUG] arg2) commit: $commit \n");
+                printf ("[DEBUG] arg3) repo: $repo \n");
+                printf ("[DEBUG] arg4) branch: $branch \n");
+                printf ("[DEBUG] arg5) pr no: $pr_no \n");
+                printf ("[DEBUG] arg6) X-GitHub-Delivery: $delivery_id \n");
+
+                // Run a shell script asynchronously to avoid service timeout generated
+                // due to a long execution time.
                 // https://stackoverflow.com/questions/222414/asynchronous-shell-exec-in-php
                 // https://stackoverflow.com/questions/2368137/asynchronous-shell-commands
-                $cmd = "./checker-pr-format.sh $date $commit $repo $branch $pr_no $delivery_id > /dev/null 2>/dev/null &";
-                $result = shell_exec($cmd);
-                printf ("[DEBUG] checker: checker-pr-format.sh is done asynchronously. \n");
-                printf ("[DEBUG] It means that checker-pr-format.sh is still running now.\n");
-                printf ("[DEBUG] ./checker-pr-format.sh $date $commit $repo $branch $pr_no $delivery_id \n");
+                $result=0;
+                $cmd="./checker-pr-gateway.sh $date $commit $repo $branch $pr_no $delivery_id > /dev/null 2>/dev/null &";
+                $result=shell_exec($cmd);
+                printf ("[DEBUG] checker: checker-pr-gateway.sh is done asynchronously. \n");
+                printf ("[DEBUG] It means that checker-pr-gateway.sh is still running now.\n");
+                printf ("[DEBUG] ./checker-pr-gateway.sh $date $commit $repo $branch $pr_no $delivery_id \n");
+
             }
 
-            // Checker: checker-pr-audit.sh
-            // Todo: handle the case that has multiple commits per PR
-            // with "foreach $payload->head as $key => $value" statement.
-            if ($payload->action == "opened" || ($payload->action == "edited" && $open_sesame == "true")||
-                $payload->action == "synchronize"){
-                printf ("\n\n");
-                printf ("[DEBUG] #### checker: starting ./checker-pr-audit.sh ...)\n");
-                echo ("[DEBUG] action: '$payload->action'. \n");
-                $date=date_time_us();
-                $commit = $payload->pull_request->head->sha;
-                $full_name = $payload->pull_request->head->repo->full_name;
-                $repo = "https://${github_dns}/${full_name}.git";
-                $branch = $payload->pull_request->head->ref;
-                $pr_no=$payload->pull_request->number;
-                $delivery_id = $_SERVER['HTTP_X_GITHUB_DELIVERY'];
-                printf ("[DEBUG] current PR number: $pr_no \n");
-                printf ("[DEBUG] checker-pr-audit.sh - arg1) date: $date \n");
-                printf ("[DEBUG] checker-pr-audit.sh - arg2) commit: $commit \n");
-                printf ("[DEBUG] checker-pr-audit.sh - arg3) repo: $repo \n");
-                printf ("[DEBUG] checker-pr-audit.sh - arg4) branch: $branch \n");
-                printf ("[DEBUG] checker-pr-audit.sh - arg5) pr no: $pr_no \n");
-                printf ("[DEBUG] checker-pr-audit.sh - arg6) X-GitHub-Delivery: $delivery_id \n");
-                $result=0;
-                // Run a script asynchronously to avoid service timeout generated due to long build time.
-                // https://stackoverflow.com/questions/222414/asynchronous-shell-exec-in-php
-                // https://stackoverflow.com/questions/2368137/asynchronous-shell-commands
-                $cmd = "./checker-pr-audit.sh $date $commit $repo $branch $pr_no $delivery_id > /dev/null 2>/dev/null &";
-                $result = shell_exec($cmd);
-                printf ("[DEBUG] checker: checker-pr-audit.sh  is done asynchronously. \n");
-                printf ("[DEBUG] It means that checker-pr-audit.sh is still running now.\n");
-                printf ("[DEBUG] ./checker-pr-audit.sh $date $commit $repo $branch $pr_no $delivery_id \n");
-            }
             break;
         case 'pull_request_review':
             break;


### PR DESCRIPTION
This commit is to unify the two check handlers such as format and audit.
Finally, "git clone" commad will be executed just once.

Fixed issue #299.

Signed-off-by: Geunsik Lim <leemgs@gmail.com>


---
# [Template] PR Description

In general, github system automatically copies your commit message for your convenience.
Please remove unused part of the template after writing your own PR description with this template.
```bash
$ git commit -s filename1 filename2 ... [enter]

Summarize changes in around 50 characters or less

More detailed explanatory text, if necessary. Wrap it to about 72
characters or so. In some contexts, the first line is treated as the
subject of the commit and the rest of the text as the body. The
blank line separating the summary from the body is critical;
various tools like `log`, `shortlog` and `rebase` can get confused 
if you run the two together.

Further paragraphs come after blank lines.

**Changes proposed in this PR:**
- Bullet points are okay, too
- Typically a hyphen or asterisk is used for the bullet, preceded
  by a single space, with blank lines in between, but conventions vary here.

Resolves: #123
See also: #456, #789

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped

**How to evaluate:**
1. Describe how to evaluate in order to be reproduced by reviewer(s).

Add signed-off message automatically by running **$git commit -s ...** command.

$ git push origin <your_branch_name>
```
