### PR TITLE
PR-gateway: run git command just once

### DIFF
--- a/ci/taos/checker-pr-audit-async.sh
+++ b/ci/taos/checker-pr-audit-async.sh
@@ -29,7 +29,7 @@
 #  arg6: delivery id
 #
 # @see directory variables
-#  $dir_ci       directory for webhooks
+#  $dir_ci       directory for webhooks (Absolute path)
 #  $dir_worker   directory for PR workers
 #  $dir_commit   directory for commits
 #
@@ -165,53 +165,20 @@ do
 done
 
 
-
-# --------------------------- git-clone module: clone git repository -------------------------------------------------
-echo "[DEBUG] Starting pr-audit....\n"
-
-# check if existing folder already exists
-if [[ -d $dir_commit ]]; then
-    echo "[DEBUG] WARN: mkdir command is failed because $dir_commit directory already exists."
-else
-    echo "[DEBUG] WARN: mkdir command is failed because $dir_commit directory does not exists."
-fi
-
-# check if github project folder already exists
-pwd
-cd $dir_commit
-if [[ -d ${PRJ_REPO_OWNER} ]]; then
-    echo "[DEBUG] WARN: ${PRJ_REPO_OWNER} already exists and is not an empty directory."
-    echo "[DEBUG] WARN: Removing the existing directory..."
-    rm -rf ./${PRJ_REPO_OWNER}
-fi
-
-# create 'report' folder to archive log files.
-mkdir ./report
-
-# run "git clone" command to download git source
-# options of 'sudo' command: 
-# 1) The -H (HOME) option sets the HOME environment variable to the home directory of the target user (root by default)
-# as specified in passwd. By default, sudo does not modify HOME.
-# 2) The -u (user) option causes sudo to run the specified command as a user other than root. To specify a uid instead of a username, use #uid.
-pwd
-sudo -Hu www-data git clone --reference ${REFERENCE_REPOSITORY} $input_repo
-if [[ $? != 0 ]]; then
-    echo "[DEBUG] ERROR: 'git clone' command is failed because of incorrect setting of CI server."
-    echo "[DEBUG] Please check /var/www/ permission, /var/www/html/.netrc, and /var/www/html/.gbs.conf."
-    echo "[DEBUG] current id: $(id)"
-    echo "[DEBUG] current path: $(pwd)"
-    echo "[DEBUG] $ sudo -Hu www-data git clone --reference ${REFERENCE_REPOSITORY} $input_repo"
-    exit 1
-fi
-
-# run "git branch" to use commits from PR branch
-cd ./${PRJ_REPO_OWNER}
-git checkout -b $input_branch origin/$input_branch
-git branch
-
 # --------------------------- audit module: start -----------------------------------------------------
+pwd
+echo -e "[DEBUG] Starting an audit checker...."
+echo -e "[DEBUG] dir_ci is '$dir_ci'" 
+echo -e "[DEBUG] dir_worker is '$dir_worker'" 
+echo -e "[DEBUG] dir_commit is '$dir_commit'"
 
-echo "[MODULE] Exception Handling: Let's skip CI-Build/UnitTest in case of no buildable files. "
+echo -e "[DEBUG] Let's move to a git repository folder."
+cd $dir_ci
+cd $dir_commit
+cd ./${PRJ_REPO_OWNER}
+echo -e "Current path: $(pwd)."
+
+echo -e "[MODULE] Exception Handling: Let's skip CI-Build/UnitTest in case of no buildable files. "
 
 # Check if PR-build can be skipped.
 # BUILD_MODE is created in order that developers can do debugging easily in console after adding new CI facility.

--- a/ci/taos/checker-pr-format-async.sh
+++ b/ci/taos/checker-pr-format-async.sh
@@ -28,7 +28,7 @@
 #  arg6:   delivery id
 #
 # @see variables to control the directories
-#  $dir_ci       directory is CI folder
+#  $dir_ci       directory is CI folder (Absolute path)
 #  $dir_worker   directory is PR worker folder
 #  $dir_commit   directory is commit folder
 #
@@ -87,7 +87,7 @@ user_id="@${Array[3]}"
 # Set folder name uniquely to run CI in different folder per a PR.
 dir_worker="repo-workers/pr-checker"
 
-# Set project repo name
+# Set project repo name of contributor
 PRJ_REPO_OWNER=`echo $(basename "${input_repo%.*}")`
 
 cd ..
@@ -108,47 +108,27 @@ export dir_commit=${dir_worker}/${input_date}-${input_pr}-${input_commit}
 message="Trigger: queued. The commit number is $input_commit."
 cibot_report $TOKEN "pending" "(INFO)TAOS/pr-format-all" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
 
-# --------------------------- git-clone module: clone git repository -------------------------------------------------
-echo -e "[DEBUG] Starting pr-format....\n"
 
-# check if existing folder exists.
-if [[ -d $dir_commit ]]; then
-    echo -e "[DEBUG] WARN: mkdir command is failed because $dir_commit directory already exists."
-fi
 
-# check if github project folder already exists
-cd $dir_commit
-if [[ -d ${PRJ_REPO_OWNER} ]]; then
-    echo -e "[DEBUG] WARN: ${PRJ_REPO_OWNER} already exists and is not an empty directory."
-    echo -e "[DEBUG] WARN: So removing the existing directory..."
-    rm -rf ./${PRJ_REPO_OWNER}
-fi
-
-# create 'report' folder to archive log files.
-mkdir ./report
-
-# run "git clone" command to download git source
+# --------------------------- CI module: start -----------------------------------------------------
 pwd
-sudo -Hu www-data git clone --reference ${REFERENCE_REPOSITORY} $input_repo
-if [[ $? != 0 ]]; then
-    echo -e "git clone --reference ${REFERENCE_REPOSITORY} $input_repo "
-    echo -e "[DEBUG] ERROR: Oooops. 'git clone' command failed."
-    exit 1
-else
-    echo -e "[DEBUG] 'git clone' command is successfully finished."
-fi
+echo -e "[DEBUG] Starting a format checker..."
+echo -e "[DEBUG] dir_ci is '$dir_ci'" 
+echo -e "[DEBUG] dir_worker is '$dir_worker'" 
+echo -e "[DEBUG] dir_commit is '$dir_commit'" 
 
-# run "git branch" to use commits from PR branch
+echo -e "[DEBUG] Let's move to a git repository folder."
+cd $dir_ci
+cd $dir_commit
 cd ./${PRJ_REPO_OWNER}
-git checkout -b $input_branch origin/$input_branch
-git branch
+echo -e "Current path: $(pwd)."
 
-echo -e "Make sure commit all changes before running this checker."
-
-# --------------------------- Jenkins module: start -----------------------------------------------------
 # archive a patch file of latest commit with 'format-patch' option
 # This *.patch file is used for nobody check.
-git format-patch -1 $input_commit --output-directory ../report/
+run_git_format_patch="git format-patch -1 $input_commit --output-directory ../report/"
+echo -e "[DEBUG] $run_git_format_patch"
+$run_git_format_patch
+ls ../report -al
 
 # declare default variables
 # check_result variable can get three values such as success, skip, and failure.


### PR DESCRIPTION
PR-gateway: run git command just once

This commit is to execute 'git clone' command just once when
contributor submits a PR. This commit is a final step to complete
the issue #299.

* Fixed issue #299.

Signed-off-by: Geunsik Lim <leemgs@gmail.com>