### PR TITLE
[Fix] Remove rpm file for unit test coverage

### DIFF
--- a/ci/gcov/coverage-generator.sh
+++ b/ci/gcov/coverage-generator.sh
@@ -45,6 +45,7 @@ gbs build -A x86_64 --define "testcoverage 1" -B $dirpath $build_root --clean
 cp $dirpath/local/repos/tizen/x86_64/RPMS/nnstreamer-unittest-coverage* $dirpath
 pushd $dirpath
 rpm2cpio $dirpath/nnstreamer-unittest-coverage* | cpio -idvm 
+rm $dirpath/nnstreamer-unittest-coverage*
 if [[ -d ../gcov_html ]]; then
     rm -rf ../gcov_html
 fi


### PR DESCRIPTION
If not, only use pre-order rpm file. so remove rpm file after making coverage

Fixed issue : https://github.com/nnsuite/nnstreamer/issues/689

Signed-off-by: Sewon Oh <sewon.oh@samsung.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [*]Passed [ ]Failed []Skipped
