### PR TITLE
Debian: fixed a not compatible version number - @open sesame 10/26 11:27

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-taos-ci (1.0-1) unstable; urgency=medium
+taos-ci (1.0) unstable; urgency=medium
 
   * Initial packaging work with dpkg-buildpackage for Ubuntu sever.
 


### PR DESCRIPTION
This commit is to fix a not compatible version naming structure.

Note that we may use a simple version number to avoid possibility of 
an unexpected generation issue when 'debuild' and 'git-buildpackage' (gbp) 
convert  ./debian/* files to *.dsc file.

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>


---

