### PR TITLE
[Fix] remove duplicated report about build fail.

### DIFF
--- a/ci/taos/checker-pr-audit-async.sh
+++ b/ci/taos/checker-pr-audit-async.sh
@@ -286,6 +286,12 @@ do
     fi
 done
 
+if [[ ${BUILD_TEST_FAIL} -eq 1 ]]; then
+    # comment a hint on failed PR to author.
+    message=":octocat: **cibot**: $user_id, A builder checker could not be completed because one of the checkers is not completed. In order to find out a reason, please go to ${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/."
+    cibot_comment $TOKEN "$message" "$GITHUB_WEBHOOK_API/issues/$input_pr/comments"
+fi
+
 # --------------------------- Report module: generate a log file and checke other conditions --------------------------
 
 # save webhook information for debugging

--- a/ci/taos/plugins-base/pr-audit-build-tizen.sh
+++ b/ci/taos/plugins-base/pr-audit-build-tizen.sh
@@ -124,10 +124,8 @@ function pr-audit-build-tizen-run-queue(){
         else
             message="Oooops. A build checker is failed. Resubmit the PR after fixing correctly. Commit number is $input_commit."
             cibot_report $TOKEN "failure" "TAOS/pr-audit-build-tizen-$1" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
-    
-            # comment a hint on failed PR to author.
-            message=":octocat: **cibot**: $user_id, A builder checker could not be completed because one of the checkers is not completed. In order to find out a reason, please go to ${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/."
-            cibot_comment $TOKEN "$message" "$GITHUB_WEBHOOK_API/issues/$input_pr/comments"
+
+            export BUILD_TEST_FAIL=1
         fi
     fi
     

--- a/ci/taos/plugins-base/pr-audit-build-ubuntu.sh
+++ b/ci/taos/plugins-base/pr-audit-build-ubuntu.sh
@@ -151,9 +151,7 @@ function pr-audit-build-ubuntu-run-queue(){
             message="Oooops. Ubuntu  build checker is failed. Resubmit the PR after fixing correctly. Commit number is $input_commit."
             cibot_report $TOKEN "failure" "TAOS/pr-audit-build-ubuntu" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
 
-            # comment a hint on failed PR to author.
-            message=":octocat: **cibot**: $user_id, Oooops. A Ubuntu builder checker could not be completed. To get a hint, please go to ${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/."
-            cibot_comment $TOKEN "$message" "$GITHUB_WEBHOOK_API/issues/$input_pr/comments"
+            export BUILD_TEST_FAIL=1
         fi
     fi
  

--- a/ci/taos/plugins-base/pr-audit-build-yocto.sh
+++ b/ci/taos/plugins-base/pr-audit-build-yocto.sh
@@ -212,9 +212,7 @@ function pr-audit-build-yocto-run-queue(){
             message="Oooops. YOCTO  build checker is failed. Resubmit the PR after fixing correctly. Commit number is $input_commit."
             cibot_report $TOKEN "failure" "TAOS/pr-audit-build-yocto" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
 
-            # comment a hint on failed PR to author.
-            message=":octocat: **cibot**: $user_id, Oooops. A YOCTO builder checker could not be completed. To get a hint, please go to ${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/."
-            cibot_comment $TOKEN "$message" "$GITHUB_WEBHOOK_API/issues/$input_pr/comments"
+            export BUILD_TEST_FAIL=1
         fi
     fi
  


### PR DESCRIPTION
now, cibot report failure when each builds fail.
so it is changed. report once after every build test.

Signed-off-by: sewon.oh <sewon.oh@samsung.com>


---
 