### PR TITLE
server: Fixed incorrect package name in install-packages.sh

### DIFF
--- a/ci/taos/webapp/install-packages.sh
+++ b/ci/taos/webapp/install-packages.sh
@@ -28,7 +28,12 @@ sudo systemctl restart apache2
 
 
 echo -e "########## for CI-system: Installing packages that are required for modules"
-sudo apt -y install  sed ps cat aha git which grep touch find wc cppcheck
+sudo apt -y install sed ps cat aha git
+sudo apt -y install which grep touch
+sudo apt -y install find wc cppcheck
+
+echo -e "########## for CI-system: Installing packages that are required for gcov/lcov"
+sudo apt -y install lcov
 
 echo -e "########## for CI-system: Installing clang-format"
 if [[ -f /etc/apt/sources.list.d/clang.list ]]; then
@@ -41,7 +46,9 @@ echo -e "########## for CI-system: Installing packages for doxygen documentation
 sudo apt -y install doxygen
 sudo apt -y install texlive-latex-base texlive-latex-extra
 sudo apt -y install latex-xcolor
-sudo apt -y install unoconv pdfunite  pdftk
+sudo apt -y install unoconv
+sudo apt -y install pdftk
+sudo apt -y install poppler-utils
 sudo apt -y install libreoffice
 sudo apt -y install evince
 
@@ -67,3 +74,5 @@ echo -e "[DEBUG] Note that you have to install Extensible SDK (eSDK) directly"
 
 
 echo -e "[DEBUG] Required packages are successfully installed...."
+echo -e "[DEBUG] If some packages are not installed, Please install the packages again."
+echo -e "[DEBUG] Then, install the TAOS-CI software as a next step."


### PR DESCRIPTION
This commit is to fix incorrect package name by replacing 'pdfunite' with
'poppler-utils' package.

**Changes proposed in this PR:**
1. Replaced pdfunite with poppler-utils
2. Added package names to run a code coverage (gcov/lcov)
3. Updated some satements for readability

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>


---
# [Template] PR Description

In general, github system automatically copies your commit message for your convenience.
Please remove unused part of the template after writing your own PR description with this template.
```bash
$ git commit -s filename1 filename2 ... [enter]

Summarize changes in around 50 characters or less

More detailed explanatory text, if necessary. Wrap it to about 72
characters or so. In some contexts, the first line is treated as the
subject of the commit and the rest of the text as the body. The
blank line separating the summary from the body is critical;
various tools like `log`, `shortlog` and `rebase` can get confused 
if you run the two together.

Further paragraphs come after blank lines.

**Changes proposed in this PR:**
- Bullet points are okay, too
- Typically a hyphen or asterisk is used for the bullet, preceded
  by a single space, with blank lines in between, but conventions vary here.

Resolves: #123
See also: #456, #789

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped

**How to evaluate:**
1. Describe how to evaluate in order to be reproduced by reviewer(s).

Add signed-off message automatically by running **$git commit -s ...** command.

$ git push origin <your_branch_name>
```
