### PR TITLE
[Fix] remove unused & unnecessary line

### DIFF
--- a/ci/taos/plugins-good/pr-format-nobody.sh
+++ b/ci/taos/plugins-good/pr-format-nobody.sh
@@ -31,7 +31,6 @@ function pr-format-nobody(){
         echo " * $filename " >> ../report/nobody-result.txt
         line_count=0
         body_count=0
-        nobody_result=0
         # let's do the while-loop statement to read data line by line
         while IFS= read -r line; do
             #If the line starts with "Subject*" then set var to "yes".
@@ -67,7 +66,6 @@ function pr-format-nobody(){
         else
             echo "[DEBUG] commit body checker is PASSED. patch file name: $filename"
             echo "[DEBUG] current directory is `pwd`"
-            check_result="success"
         fi
     done
     if [[ $check_result == "success" ]]; then


### PR DESCRIPTION
remove unused variable and unncessary lin.

Signed-off-by: sewon.oh <sewon.oh@samsung.com>


---
# [Template] PR Description

In general, github system automatically copies your commit message for your convenience.
Please remove unused part of the template after writing your own PR description with this template.
```bash
$ git commit -s filename1 filename2 ... [enter]

Summarize changes in around 50 characters or less

More detailed explanatory text, if necessary. Wrap it to about 72
characters or so. In some contexts, the first line is treated as the
subject of the commit and the rest of the text as the body. The
blank line separating the summary from the body is critical;
various tools like `log`, `shortlog` and `rebase` can get confused 
if you run the two together.

Further paragraphs come after blank lines.

**Changes proposed in this PR:**
- Bullet points are okay, too
- Typically a hyphen or asterisk is used for the bullet, preceded
  by a single space, with blank lines in between, but conventions vary here.

Resolves: #123
See also: #456, #789

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped

**How to evaluate:**
1. Describe how to evaluate in order to be reproduced by reviewer(s).

Add signed-off message automatically by running **$git commit -s ...** command.

$ git push origin <your_branch_name>
```
