### PR TITLE
doc: update a cron manual for pbuilder

### DIFF
--- a/ci/doc/how-to-setup-taos-ci-server.md
+++ b/ci/doc/how-to-setup-taos-ci-server.md
@@ -109,7 +109,7 @@ $ chown -R www-data:www-data /var/cache/pbuilder
 $
 $ sudo vi /etc/crontab
 ## Update a base Ubuntu image (e.g., /var/cache/pbuilder/base.tgz) of pdebuild/pbuilder to keep latest apt repositories.
-30 7 * * * www-data pbuilder update --override-config
+30 7 * * * root pbuilder update --override-config
 ```
 **(Optional)**: How to suppress a storage usage of /var/cache/pbuilder folder
 If /var/cache/pbuilder increases a storage usage, we recommend that you try to use a symbolic link.


### PR DESCRIPTION
This commit is to fix an incorrect guide to set-up a base image of pbuilder.
Note that user can not access to /usr/sbin/ folder that 'pbuilder' is located
according to the security policy of Ubuntu distribution.

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>


---
# [Template] PR Description

In general, github system automatically copies your commit message for your convenience.
Please remove unused part of the template after writing your own PR description with this template.
```bash
$ git commit -s filename1 filename2 ... [enter]

Summarize changes in around 50 characters or less

More detailed explanatory text, if necessary. Wrap it to about 72
characters or so. In some contexts, the first line is treated as the
subject of the commit and the rest of the text as the body. The
blank line separating the summary from the body is critical;
various tools like `log`, `shortlog` and `rebase` can get confused 
if you run the two together.

Further paragraphs come after blank lines.

**Changes proposed in this PR:**
- Bullet points are okay, too
- Typically a hyphen or asterisk is used for the bullet, preceded
  by a single space, with blank lines in between, but conventions vary here.

Resolves: #123
See also: #456, #789

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped

**How to evaluate:**
1. Describe how to evaluate in order to be reproduced by reviewer(s).

Add signed-off message automatically by running **$git commit -s ...** command.

$ git push origin <your_branch_name>
```
