### PR TITLE
API: Added goto_repodir(3) to help new module developers

### DIFF
--- a/ci/doc/how-to-use-taos-ci-module.md
+++ b/ci/doc/how-to-use-taos-ci-module.md
@@ -1,10 +1,17 @@
 
 ## How to develop new module
-Please implement a module in `./plugins-{base|good|staging}` folder if you need to develop new CI module for your own project. We recommend that you use two APIs such as `cibot_comment()` and `cibot_report()` in case that you have to send a webhook message to a GitHub website. You can easily develop new CI module by referencing the existing CI modules because we follow up the Wiki philosophy.
-   - `plugins-base`: it is a well-maintained collection of CI plugins. A wide rang of Tizen (gbs) and Ubuntu (pdebuild) are included.
-   - `plugins-good`: it is a set of plug-ins that we consider to have good quality code, correct functionality, our preferred license (Apache for the plug-in code).
-   - `plugins-staging`: it is a set of plug-ins that are not up to par compared to the rest. They might be close to being good quality, but they are missing something - be it a good code review, some documentation, a set of tests, or aging test.
+Please implement a module in `./plugins-{base|good|staging}` folder if you need to develop new CI module for your own project.
+You can easily develop new CI module by referencing the existing CI modules because we follow up the Wiki philosophy.
+* `plugins-base`: it is a well-maintained collection of CI plugins. A wide rang of Tizen (gbs) and Ubuntu (pdebuild) are included.
+* `plugins-good`: it is a set of plug-ins that we consider to have good quality code, correct functionality, our preferred license (Apache for the plug-in code).
+* `plugins-staging`: it is a set of plug-ins that are not up to par compared to the rest. They might be close to being good quality, but they are missing something - be it a good code review, some documentation, a set of tests, or aging test.
 
+## Provied public APIs
+We recommend that you use two APIs such as `cibot_comment()` and `cibot_report()` in case that you have to send a webhook message to a GitHub website. Also, we provide the `goto_repodir()` to go to a git repository folder as a work folder.
+* cibot_comment(): This API write a requested message into a webpage of issue number or PR number.
+* cibot_report(): The API update the current status of the context of the module.
+* goto_repodir(): This API is to change a folder location from a current directory to a git repostiory directory.
+* check_dependency(): This API is to check if required commands are installed in the server.
 
 ## How to enable new module
 First, open `./config/config-plugins-{format|audit}.sh`. Then, append a function name of a module that you want to attach newly. If you are poor at CI module, we recommend that you refer to the existing examples.

--- a/ci/taos/common/api_collection.sh
+++ b/ci/taos/common/api_collection.sh
@@ -102,6 +102,18 @@ function cibot_report(){
 }
 
 ##
+# @brief API to move to a git repository folder that imported a specified branch name
+# @param
+# argument: none
+function goto_repodir(){
+    echo -e "[DEBUG] Let's move to a git repository folder."
+    cd $dir_ci
+    cd $dir_commit
+    cd ./${PRJ_REPO_OWNER}
+    echo -e "Current path: $(pwd)."
+}
+
+##
 #  @brief check if a pcakge is installed
 #  @param
 #   arg1: package name


### PR DESCRIPTION
Fixed issue #362.

This commit is to append goto_repodir(3) API in order that the developer
can make new module more easily.

**Changes proposed in this PR:**
1. Added goto_repodir(3)
2. Updated the existing document

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>


---
# [Template] PR Description

In general, github system automatically copies your commit message for your convenience.
Please remove unused part of the template after writing your own PR description with this template.
```bash
$ git commit -s filename1 filename2 ... [enter]

Summarize changes in around 50 characters or less

More detailed explanatory text, if necessary. Wrap it to about 72
characters or so. In some contexts, the first line is treated as the
subject of the commit and the rest of the text as the body. The
blank line separating the summary from the body is critical;
various tools like `log`, `shortlog` and `rebase` can get confused 
if you run the two together.

Further paragraphs come after blank lines.

**Changes proposed in this PR:**
- Bullet points are okay, too
- Typically a hyphen or asterisk is used for the bullet, preceded
  by a single space, with blank lines in between, but conventions vary here.

Resolves: #123
See also: #456, #789

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped

**How to evaluate:**
1. Describe how to evaluate in order to be reproduced by reviewer(s).

Add signed-off message automatically by running **$git commit -s ...** command.

$ git push origin <your_branch_name>
```
