### PR TITLE
[Fix] change report name

### DIFF
--- a/ci/taos/plugins-good/pr-format-signed-off-by.sh
+++ b/ci/taos/plugins-good/pr-format-signed-off-by.sh
@@ -71,12 +71,12 @@ function pr-format-signed-off-by(){
         # in case of success
         echo "[DEBUG] Passed. There is no signed-off-by issue."
         message="Successfully signedoff! This PR includes Signed-off-by: string."
-        cibot_report $TOKEN "success" "TAOS/pr-format-signedoff" "$message" "$REPOSITORY_WEB/pull/$input_pr/commits/$input_commit" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+        cibot_report $TOKEN "success" "TAOS/pr-format-signed-off-by" "$message" "$REPOSITORY_WEB/pull/$input_pr/commits/$input_commit" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
     elif [[ $check_result == "failure" ]]; then
         echo "[DEBUG] Failed. There is no signed-off-by in this commit."
         # in case of failure
         message="Oooops. No signedoff found. This PR does not include 'Signed-off-by:' string. The lawyers tell us we must have it."
-        cibot_report $TOKEN "failure" "TAOS/pr-format-signedoff" "$message" "$REPOSITORY_WEB/pull/$input_pr/commits/$input_commit" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+        cibot_report $TOKEN "failure" "TAOS/pr-format-signed-off-by" "$message" "$REPOSITORY_WEB/pull/$input_pr/commits/$input_commit" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
 
         # inform contributors of meaning of Signed-off-by: statement
         message="To contributor, We have used '**Signed-off-by:**' notation by default to handle the license issues, that result from contributors. Note that 'Is there a Signed-off-by line?' is important because lawyers tell us we must have to it **to cleanly maintain the open-source license issues** even though it has nothing to do with the code itself."
@@ -84,7 +84,7 @@ function pr-format-signed-off-by(){
     else
         # in case of CI error
         message="Oooops. It seems that CI bot includes bug(s). CI bot has to be fixed."
-        cibot_report $TOKEN "error" "TAOS/pr-format-signedoff" "$message" "$REPOSITORY_WEB/pull/$input_pr/commits/$input_commit" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+        cibot_report $TOKEN "error" "TAOS/pr-format-signed-off-by" "$message" "$REPOSITORY_WEB/pull/$input_pr/commits/$input_commit" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
     fi
 }
 


### PR DESCRIPTION
change name from 'signedoff' to 'signed-off-by'

Signed-off-by: sewon.oh <sewon.oh@samsung.com>


---
# [Template] PR Description

In general, github system automatically copies your commit message for your convenience.
Please remove unused part of the template after writing your own PR description with this template.
```bash
$ git commit -s filename1 filename2 ... [enter]

Summarize changes in around 50 characters or less

More detailed explanatory text, if necessary. Wrap it to about 72
characters or so. In some contexts, the first line is treated as the
subject of the commit and the rest of the text as the body. The
blank line separating the summary from the body is critical;
various tools like `log`, `shortlog` and `rebase` can get confused 
if you run the two together.

Further paragraphs come after blank lines.

**Changes proposed in this PR:**
- Bullet points are okay, too
- Typically a hyphen or asterisk is used for the bullet, preceded
  by a single space, with blank lines in between, but conventions vary here.

Resolves: #123
See also: #456, #789

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped

**How to evaluate:**
1. Describe how to evaluate in order to be reproduced by reviewer(s).

Add signed-off message automatically by running **$git commit -s ...** command.

$ git push origin <your_branch_name>
```
