### PR TITLE
Create CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,53 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project based on meritocracy and our community a harassment-free experience for everyone.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the project
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Contributors' Responsibilities
+
+By submitting a code, you are guaranteeing, up your best knowledge, that
+* The content of the submitted code is not patented or you are providing the right to practice the related patents according to the license of NNStreamer to NNStreamer users and developers.
+* You have the right to contribute the code; you have the copyright (or the copyright holder has permitted to submit the code to NNStreamer). If your code is done for a employer, the employer may have the right to the code.
+* You have tested and verified the code.
+* You allow the maintainers to update the license of the project later as long as the update does not conflict with the base code of this project. The base code is the code before your contribution.
+
+## Scope
+
+This Code of Conduct applies within official project spaces and official events of the project.
+Note that the official project spaces may include more in the future although we have github.com only for now.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project email at nnsuite@samsung.com. The maintainer will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+## Attribution
+
+This Code of Conduct is a modified one from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version].
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/
+


### PR DESCRIPTION
Fixed issue #264.

This commit is to append the Code Of Conduct (COC) in the TAOS-CI repository.
This file is mirrored from CODE_OF_CONDUCT.md of NNStreamer.

**Changes proposed in this PR:**
1. Added CODE_OF_CONDUCT.md

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>


---
 