### PR TITLE
[Tizen] When arch x86_64 gbs build, add unit test flag

### DIFF
--- a/ci/taos/plugins-base/pr-audit-build-tizen.sh
+++ b/ci/taos/plugins-base/pr-audit-build-tizen.sh
@@ -55,6 +55,12 @@ function pr-audit-build-tizen-run-queue(){
     # BUILD_MODE=99: skip "gbs build" procedures
     BUILD_MODE=$BUILD_MODE_TIZEN
 
+    # TODO: We need to decide a prefix policy consistently for maintenance and
+    # compatibility of TAOS-CI,
+    # For example,
+    # 1) _common_*****
+    # 2) _nnstreamer_****
+    # 3) _another_****
     # build package
     echo -e "[DEBUG] gbs build start at :"
     date -R
@@ -75,16 +81,30 @@ function pr-audit-build-tizen-run-queue(){
         --buildroot ./GBS-ROOT/  | tee ../report/build_log_${input_pr}_tizen_$1_output.txt
     else
         echo -e "BUILD_MODE = 0"
-        sudo -Hu www-data gbs build \
-        -A $1 \
-        --clean \
-        --define "_smp_mflags -j${CPU_NUM}" \
-        --define "_pr_context pr-audit" \
-        --define "_pr_number ${input_pr}" \
-        --define "__ros_verify_enable 1" \
-        --define "_pr_start_time ${input_date}" \
-        --define "_skip_debug_rpm 1" \
-        --buildroot ./GBS-ROOT/ 2> ../report/build_log_${input_pr}_tizen_$1_error.txt 1> ../report/build_log_${input_pr}_tizen_$1_output.txt
+        if [[ $1 == "x86_64" ]]; then
+            sudo -Hu www-data gbs build \
+            -A $1 \
+            --clean \
+            --define "_smp_mflags -j${CPU_NUM}" \
+            --define "_pr_context pr-audit" \
+            --define "_pr_number ${input_pr}" \
+            --define "__ros_verify_enable 1" \
+            --define "_pr_start_time ${input_date}" \
+            --define "_skip_debug_rpm 1" \
+            --define "unit_test 1" \ 
+            --buildroot ./GBS-ROOT/ 2> ../report/build_log_${input_pr}_tizen_$1_error.txt 1> ../report/build_log_${input_pr}_tizen_$1_output.txt
+        else
+            sudo -Hu www-data gbs build \
+            -A $1 \
+            --clean \
+            --define "_smp_mflags -j${CPU_NUM}" \
+            --define "_pr_context pr-audit" \
+            --define "_pr_number ${input_pr}" \
+            --define "__ros_verify_enable 1" \
+            --define "_pr_start_time ${input_date}" \
+            --define "_skip_debug_rpm 1" \
+            --buildroot ./GBS-ROOT/ 2> ../report/build_log_${input_pr}_tizen_$1_error.txt 1> ../report/build_log_${input_pr}_tizen_$1_output.txt
+        fi        
     fi
     result=$?
     echo -e "[DEBUG] gbs build finished at :"


### PR DESCRIPTION
For unit test of nnstreamer, add flag.

Signed-off-by: sewon.oh <sewon.oh@samsung.com>


---
# [Template] PR Description

In general, github system automatically copies your commit message for your convenience.
Please remove unused part of the template after writing your own PR description with this template.
```bash
$ git commit -s filename1 filename2 ... [enter]

Summarize changes in around 50 characters or less

More detailed explanatory text, if necessary. Wrap it to about 72
characters or so. In some contexts, the first line is treated as the
subject of the commit and the rest of the text as the body. The
blank line separating the summary from the body is critical;
various tools like `log`, `shortlog` and `rebase` can get confused 
if you run the two together.

Further paragraphs come after blank lines.

**Changes proposed in this PR:**
- Bullet points are okay, too
- Typically a hyphen or asterisk is used for the bullet, preceded
  by a single space, with blank lines in between, but conventions vary here.

Resolves: #123
See also: #456, #789

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped

**How to evaluate:**
1. Describe how to evaluate in order to be reproduced by reviewer(s).

Add signed-off message automatically by running **$git commit -s ...** command.

$ git push origin <your_branch_name>
```
