### PR TITLE
[Fix] Remove blank at tizen build option.

### DIFF
--- a/ci/taos/plugins-base/pr-audit-build-tizen.sh
+++ b/ci/taos/plugins-base/pr-audit-build-tizen.sh
@@ -91,7 +91,7 @@ function pr-audit-build-tizen-run-queue(){
             --define "__ros_verify_enable 1" \
             --define "_pr_start_time ${input_date}" \
             --define "_skip_debug_rpm 1" \
-            --define "unit_test 1" \ 
+            --define "unit_test 1" \
             --buildroot ./GBS-ROOT/ 2> ../report/build_log_${input_pr}_tizen_$1_error.txt 1> ../report/build_log_${input_pr}_tizen_$1_output.txt
         else
             sudo -Hu www-data gbs build \


### PR DESCRIPTION
This blank make error that 'command not found'

Signed-off-by: sewon.oh <sewon.oh@samsung.com>


---
 