### PR TITLE
Remove license statement in configuration files

### DIFF
--- a/ci/taos/config/config-environment.sh
+++ b/ci/taos/config/config-environment.sh
@@ -1,18 +1,6 @@
 #!/usr/bin/env bash
 
-##
-# Copyright (c) 2018 Samsung Electronics Co., Ltd. All Rights Reserved.
-# 
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
+# Do not append a license statement in the configuration file for a differnet license-based repository.
 
 ##
 # @file     config-environment.sh

--- a/ci/taos/config/config-plugins-audit.sh
+++ b/ci/taos/config/config-plugins-audit.sh
@@ -1,18 +1,6 @@
 #!/usr/bin/env bash
 
-##
-# Copyright (c) 2018 Samsung Electronics Co., Ltd. All Rights Reserved.
-# 
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
+# Do not append a license statement in the configuration file for a differnet license-based repository.
 
 ##
 # @file     config-plugins-audit.sh

--- a/ci/taos/config/config-plugins-format.sh
+++ b/ci/taos/config/config-plugins-format.sh
@@ -1,18 +1,6 @@
 #!/usr/bin/env bash
 
-##
-# Copyright (c) 2018 Samsung Electronics Co., Ltd. All Rights Reserved.
-# 
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
+# Do not append a license statement in the configuration file for a differnet license-based repository.
 
 ##
 # @file     config-plugins-format.sh

--- a/ci/taos/config/config-server-administrator.sh
+++ b/ci/taos/config/config-server-administrator.sh
@@ -1,18 +1,6 @@
 #!/usr/bin/env bash
 
-##
-# Copyright (c) 2018 Samsung Electronics Co., Ltd. All Rights Reserved.
-# 
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
+# Do not append a license statement in the configuration file for a differnet license-based repository.
 
 ##
 # @file config-server-administrator.sh


### PR DESCRIPTION
This commit is to remove the existing license statements in the configuration files.
It aims to give users convenience when a github repository (that use different license)
try to introduce TAOS-CI system.

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>


---
