### PR TITLE
[nnstreamer/apptest] Fix apptest failure

### DIFF
--- a/ci/taos/plugins-staging/pr-audit-nnstreamer-ubuntu-apptest.sh
+++ b/ci/taos/plugins-staging/pr-audit-nnstreamer-ubuntu-apptest.sh
@@ -74,7 +74,7 @@ function pr-audit-nnstreamer-ubuntu-apptest-run-queue() {
     # Set-up environment variables.
     export NNST_ROOT="${dir_ci}/${dir_commit}/${PRJ_REPO_OWNER}"
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$NNST_ROOT/lib
-    export GST_PLUGIN_PATH=$GST_PLUGIN_PATH:$NNST_ROOT/lib
+    export GST_PLUGIN_PATH=$GST_PLUGIN_PATH:$NNST_ROOT/lib/gstreamer-1.0
     echo -e "[DEBUG] NNST_ROOT is '$NNST_ROOT'"
     echo -e "[DEBUG] LD_LIBRARY_PATH is '$LD_LIBRARY_PATH'"
     echo -e "[DEBUG] GST_PLUGIN_PATH is '$GST_PLUGIN_PATH'"
@@ -90,8 +90,8 @@ function pr-audit-nnstreamer-ubuntu-apptest-run-queue() {
     fi
     cd build
     cmake -DCMAKE_INSTALL_PREFIX=${NNST_ROOT} \
-    -DINCLUDE_INSTALL_DIR=${NNST_ROOT}/include \
-    -DGST_INSTALL_DIR=${NNST_ROOT}/lib ..
+        -DCMAKE_INSTALL_LIBDIR=lib \
+        ..
     make install
     cd ..
 


### PR DESCRIPTION
---
# PR Description

Resolves the PR https://github.com/nnsuite/nnstreamer/pull/896

Since https://github.com/nnsuite/nnstreamer/pull/896 moves libtensor_filter_tflitecore.so to ${libdir} from ${gst_install_dir}, the audit for apptest on Ubuntu was failed. This PR resolves this issue.

**Changes proposed in this PR:**
* Version 3:
  - The missing cmake argument, -DCMAKE_INSTALL_LIBDIR=lib, is added.
* Version 2:
  - This PR is changed to include only related one patch
* Version 1:
  - [nnstreamer/apptest] Revise cmake arguments


**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped

Signed-off-by: Wook Song <wook16.song@samsung.com>