### PR TITLE
nnstreamer/apptest: Added debug message to display  environment

### DIFF
--- a/ci/taos/plugins-staging/pr-audit-nnstreamer-ubuntu-apptest.sh
+++ b/ci/taos/plugins-staging/pr-audit-nnstreamer-ubuntu-apptest.sh
@@ -205,6 +205,9 @@ function pr-audit-nnstreamer-ubuntu-apptest-run-queue() {
     producer_id=$!
 
     echo -e "[DEBUG] The producer (pid: ${producer_id}) is successfully started."
+    echo -e "[DEBUG] -------------------- env: start --------------------"
+    env
+    echo -e "[DEBUG] -------------------- env: start --------------------"
 
     ## App: Test /dev/video0 status with gst-lanch-1.0 command 
     ## The dependency: /dev/video0, VNC


### PR DESCRIPTION

* Related issue: https://github.com/nnsuite/nnstreamer/issues/905

It is to add help debug message additionally. This commit is to append
a debug message in order that the developer can monitor a current
environment setting content with 'env' command.

**Changes proposed in this PR:**
1. Added 'env' command to display meaningful log message additionally

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>


---
