### PR TITLE
build/ubuntu: Change ubuntu pack folder

### DIFF
--- a/ci/taos/plugins-base/pr-audit-build-ubuntu.sh
+++ b/ci/taos/plugins-base/pr-audit-build-ubuntu.sh
@@ -104,10 +104,10 @@ function pr-audit-build-ubuntu-run-queue(){
         # If the debian files exists, let's remove these files.
         debfiles=(../*.dsc)
         if [[ -f ${debfiles[0]} ]]; then
-            mkdir ../$PACK_BIN_FOLDER
+            mkdir -p ../$PACK_BIN_FOLDER/DEBS
             echo "Removing unnecessary debian files..."
             echo "The binary files will be temporarily archived in /var/cache/pbuilder/ folder."
-            sudo mv ../*.deb ../$PACK_BIN_FOLDER
+            sudo mv ../*.deb ../$PACK_BIN_FOLDER/DEBS
             sudo rm -rf ../*.tar.gz ../*.dsc ../*.changes
             if [[ $? -ne 0 ]]; then
                 echo "[DEBUG][FAILED] Ubuntu/pdebuild: Oooops!!!!! Unnecessary files are not removed."


### PR DESCRIPTION
This commit is to change the existing folder name of the Ubuntu pakcages
as following:

* Before:
./binary_repository/RPMS/
./binary_repository/

* After:
./binary_repository/RPMS/ (for Tizen)
./binary_repository/DEBS/ (for Ubuntu)

Signed-off-by: nnsuite <nnsuite@samsung.com>


---
 
