### PR TITLE
Audit modules: Specify a default locale policy.

### DIFF
--- a/ci/taos/common/global-variable.sh
+++ b/ci/taos/common/global-variable.sh
@@ -3,3 +3,12 @@
 # Specify a folder name to archive packages files (e.g., .rpm, .deb)
 PACK_BIN_FOLDER="binary_repository"
 
+# Specify a default locale policy.
+# We recommend that you use a locale setting which supports UTF-8.
+# Case study:
+# 1) Yocto: "devtool add/build" command is not executed because it is written by a UTF-8 library.
+# 2) Download: A log message is broken while downloading a file with no locale setting 
+export LC_ALL=en_US.UTF-8
+export LANG=en_US.UTF-8
+export LANGUAGE=en_US:en
+

--- a/ci/taos/plugins-base/pr-audit-build-yocto.sh
+++ b/ci/taos/plugins-base/pr-audit-build-yocto.sh
@@ -67,13 +67,13 @@ function pr-audit-build-yocto-run-queue(){
     echo "[MODULE] TAOS/pr-audit-build-yocto: check build process for YOCTO distribution"
 
     # Note that you have to declare language set to avoid the execution error of "devtool add/build" command because
-    # Python can not change the filesystem locale after loading so we need a utf-8 when python starts or things won't work.
+    # Python can not change the filesystem locale after loading so we need a UTF-8 when python starts or things won't work.
     # Use a locale setting which supports utf-8.
     # See https://github.com/openembedded/openembedded-core/blob/master/scripts/devtool#L212
     # See https://github.com/openembedded/bitbake/blob/master/bin/bitbake#L38
-    export LANG=en_US.UTF-8
     export LC_ALL=en_US.UTF-8
-    export LANGUAGE=en_US.UTF-8
+    export LANG=en_US.UTF-8
+    export LANGUAGE=en_US:en
     echo "[DEBUG] locale information: start ---------------------------------------------"
     locale
     echo "[DEBUG] locale information: end   ---------------------------------------------"

--- a/ci/taos/plugins-staging/pr-audit-nnstreamer-ubuntu-apptest.sh
+++ b/ci/taos/plugins-staging/pr-audit-nnstreamer-ubuntu-apptest.sh
@@ -211,6 +211,11 @@ function pr-audit-nnstreamer-ubuntu-apptest-run-queue() {
     #  a. Run an appliction while 2 seconds arbitrarily in virtual network environment.
     #  b. Kill a process after 2 seconds. Otherwise, the process runs forever.
 
+    # Display a current locale setting.
+    echo -e "[DEBUG] -------------------- locale: start --------------------"
+    locale
+    echo -e "[DEBUG] -------------------- locale: start --------------------"
+
     # Display a port status to check a port that Xvnc has opened.
     echo -e "[DEBUG] -------------------- netstat: start --------------------"
     netstat -natp | grep [^]]:60


### PR DESCRIPTION
* Related issue: https://github.com/nnsuite/nnstreamer/issues/905
  - Fix broken message in the output file
   (e.g., 쁬obilenet_v1_1.0_224_quant.tflite, 쁫abels.txt)

This commit is to declare a default locale policy for build modules.
From our experience, we need to use a locale setting which supports UTF-8
to avoid an unexpected locale issue while running audit modules.

* Case study:
 1) Yocto: "devtool add/build" command is not executed because it is written by a UTF-8 library.
 2) Download: A log message is broken while downloading a file with no locale setting

* Defaut policy:
export LC_ALL=en_US.UTF-8
export LANG=en_US.UTF-8
export LANGUAGE=en_US:en

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>


---
 

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped

**How to evaluate:**
1. Describe how to evaluate in order to be reproduced by reviewer(s).

Add signed-off message automatically by running **$git commit -s ...** command.

$ git push origin <your_branch_name>
```
