### PR TITLE
doc: Fix a broken link to the 'Build Status' page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![GitHub license](https://dmlc.github.io/img/apache2.svg)](./LICENSE)
 
-[Build Status](http://invain.mooo.com/TAOS-CI/ci/taos/) |
+[Build Status](http://nnsuite.mooo.com/TAOS-CI/ci/taos/) |
 [Documentation](ci/doc/doxygen-documentation.md) |
 [Contributing](ci/doc/contributing.md) |
 [Chat Room](https://gitter.im/login) |


### PR DESCRIPTION
This patch fixes a broken link to the 'Build Status' page.

Signed-off-by: Wook Song <wook16.song@samsung.com>