### PR TITLE
version management: sync version between packaging files

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,16 @@
+taos-ci (1.2) unstable; urgency=medium
+
+  * WEB: Added monitor to show running PRs to build Android binaries
+  * Android/ARM64: interconnect android build module and apache web
+  * Audit group: Support a Android build module for C/C++
+  * Published ICCE paper
+  * admin: update the webhoo api script for maintenance
+  * module: doxygen-tag: Fix broken link to doxygen-documentation
+  * [nnstreamer/apptest] run apptest with meson
+  * nnstreamer/apptest: Renamed Xvnc variables for maintenance
+
+ -- Geunsik Lim <geunsik.lim@samsung.com>  Thu, 07 Mar 2019 07:30:32 +0900
+
 taos-ci (1.1) unstable; urgency=medium
 
   * Added a spelling module, issue #168

--- a/packaging/taos-ci.spec
+++ b/packaging/taos-ci.spec
@@ -1,7 +1,10 @@
 Name:		taos-ci
 Summary:	TAOS CI Suite
-Version:	1.0
-Release:	1
+# Synchronize the version information between Ubuntu and Tizen.
+# 1. Ubuntu : ./debian/changelog
+# 2. Tizen  : ./packaging/nnstreamer.spec
+Version:	1.2
+Release:	0
 License:	Apache-2.0
 Group:		Development
 BuildArch:	noarch


### PR DESCRIPTION
This commit is to synchronize the version info between packaging
files such as ./debian/changelog and ./packaging/taos-ci.spec file.

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>


---