### PR TITLE
plugin-base: Added a time checker to display a build time of PR

### DIFF
--- a/ci/taos/plugins-base/pr-audit-build-android.sh
+++ b/ci/taos/plugins-base/pr-audit-build-android.sh
@@ -106,6 +106,9 @@ function pr-audit-build-android-run-queue(){
     # BUILD_MODE=99: skip "ndk-build" procedures
     BUILD_MODE=$BUILD_MODE_ANDROID
 
+    # Put a timer in front of the build job to check a start time.
+    time_start=$(date +"%s")
+
     # Build a package
     result=0
     if [[ $BUILD_MODE == 99 ]]; then
@@ -168,6 +171,11 @@ function pr-audit-build-android-run-queue(){
     fi
     echo "[DEBUG] The result value is '$result'."
 
+    # Put a timer behind the build job to check an end time.
+    time_end=$(date +"%s")
+    time_diff=$(($time_end-$time_start))
+    time_build_cost="$(($time_diff / 60)) minutes and $(($time_diff % 60)) seconds"
+
     # Report a test result
     # Let's run the build procedure. Or skip the build procedure according to $BUILD_MODE.
     if [[ $BUILD_MODE == 99 ]]; then
@@ -198,10 +206,10 @@ function pr-audit-build-android-run-queue(){
 
         # Let's report build result of source code
         if [[ $check_result == "success" ]]; then
-            message="Successfully Android build checker is passed. Commit number is '$input_commit'."
+            message="Android.build Successful in $time_build_cost. Commit number is '$input_commit'."
             cibot_report $TOKEN "success" "TAOS/pr-audit-build-android" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
         else
-            message="Oooops. Android build checker is failed. Resubmit the PR after fixing correctly. Commit number is $input_commit."
+            message="Android.build Failure after $time_build_cost. Resubmit the PR after fixing correctly. Commit number is $input_commit."
             cibot_report $TOKEN "failure" "TAOS/pr-audit-build-android" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
 
             export BUILD_TEST_FAIL=1

--- a/ci/taos/plugins-base/pr-audit-build-tizen.sh
+++ b/ci/taos/plugins-base/pr-audit-build-tizen.sh
@@ -62,6 +62,9 @@ function pr-audit-build-tizen-run-queue(){
     # 2) _nnstreamer_****
     # 3) _another_****
 
+    # Put a timer in front of the build job to check a start time.
+    time_start=$(date +"%s")
+
     # Build a package with gbs command.
     # TODO: Simplify the existing if...else statement for readability and maintenance
     echo -e "[DEBUG] gbs build start at : $(date -R)."
@@ -113,6 +116,11 @@ function pr-audit-build-tizen-run-queue(){
     echo -e "[DEBUG] gbs build finished at : $(date -R)."
     echo -e "[DEBUG] The variable result value is $result."
 
+    # Put a timer behind the build job to check an end time.
+    time_end=$(date +"%s")
+    time_diff=$(($time_end-$time_start))
+    time_build_cost="$(($time_diff / 60)) minutes and $(($time_diff % 60)) seconds"
+
     # If the ./GBS-ROOT/ folder exists, let's remove this folder.
     # Note that this folder consume too many storage space (on average 9GiB).
     if [[ -d GBS-ROOT ]]; then
@@ -159,10 +167,10 @@ function pr-audit-build-tizen-run-queue(){
     
         # Let's report build result of source code
         if [[ $check_result == "success" ]]; then
-            message="Successfully a build checker is passed. Commit number is '$input_commit'."
+            message="Tizen.build Successful in $time_build_cost. Commit number is '$input_commit'."
             cibot_report $TOKEN "success" "TAOS/pr-audit-build-tizen-$1" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
         else
-            message="Oooops. A build checker is failed. Resubmit the PR after fixing correctly. Commit number is $input_commit."
+            message="Tizen.build Failure after $time_build_cost. Commit number is $input_commit."
             cibot_report $TOKEN "failure" "TAOS/pr-audit-build-tizen-$1" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
 
             export BUILD_TEST_FAIL=1

--- a/ci/taos/plugins-base/pr-audit-build-ubuntu.sh
+++ b/ci/taos/plugins-base/pr-audit-build-ubuntu.sh
@@ -72,6 +72,8 @@ function pr-audit-build-ubuntu-run-queue(){
     # BUILD_MODE=99: skip "pdebuild" procedures
     BUILD_MODE=$BUILD_MODE_UBUNTU
 
+    # Put a timer in front of the build job to check a start time.
+    time_start=$(date +"%s")
     # Build a package
     if [[ $BUILD_MODE == 99 ]]; then
         # skip build procedure
@@ -120,6 +122,12 @@ function pr-audit-build-ubuntu-run-queue(){
     fi
     echo "[DEBUG] The variable result value is $result."
 
+    # Put a timer behind the build job to check an end time.
+    time_end=$(date +"%s")
+    time_diff=$(($time_end-$time_start))
+    time_build_cost="$(($time_diff / 60)) minutes and $(($time_diff % 60)) seconds"
+
+
     # report execution result
     # let's do the build procedure of or skip the build procedure according to $BUILD_MODE
     if [[ $BUILD_MODE == 99 ]]; then
@@ -140,20 +148,20 @@ function pr-audit-build-ubuntu-run-queue(){
         echo -e "[DEBUG] The return value of pdebuild command is $result."
         # Let's check if build procedure is normally done.
         if [[ $result -eq 0 ]]; then
-                echo -e "[DEBUG][PASSED] Successfully Ubunu build checker is passed. Return value is ($result)."
+                echo -e "[DEBUG][PASSED] Successfully Ubunu build checker is passed in $time_build_cost."
                 check_result="success"
         else
-                echo -e "[DEBUG][FAILED] Oooops!!!!!! Ubuntu build checker is failed. Return value is ($result)."
+                echo -e "[DEBUG][FAILED] Oooops!!!!!! Ubuntu build checker is failed after $time_build_cost. "
                 check_result="failure"
                 global_check_result="failure"
         fi
 
         # Let's report build result of source code
         if [[ $check_result == "success" ]]; then
-            message="Successfully  Ubuntu build checker is passed. Commit number is '$input_commit'."
+            message="Ubuntu.build Successful in $time_build_cost. Commit number is '$input_commit'."
             cibot_report $TOKEN "success" "TAOS/pr-audit-build-ubuntu" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
         else
-            message="Oooops. Ubuntu  build checker is failed. Resubmit the PR after fixing correctly. Commit number is $input_commit."
+            message="Ubuntu.build Failure after $time_build_cost. Commit number is $input_commit."
             cibot_report $TOKEN "failure" "TAOS/pr-audit-build-ubuntu" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
 
             export BUILD_TEST_FAIL=1

--- a/ci/taos/plugins-base/pr-audit-build-yocto.sh
+++ b/ci/taos/plugins-base/pr-audit-build-yocto.sh
@@ -109,6 +109,9 @@ function pr-audit-build-yocto-run-queue(){
     # BUILD_MODE=99: skip "gbs build" procedures
     BUILD_MODE=$BUILD_MODE_YOCTO
 
+    # Put a timer in front of the build job to check a start time.
+    time_start=$(date +"%s")
+
     # Build a package for Yocto
     if [[ $BUILD_MODE == 99 ]]; then
         # Skip a build procedure because BUILD_MODE is 99
@@ -163,6 +166,11 @@ function pr-audit-build-yocto-run-queue(){
 
     echo "[DEBUG] The return value (build_result) of 'devtool build' command is $build_result."
 
+    # Put a timer behind the build job to check an end time.
+    time_end=$(date +"%s")
+    time_diff=$(($time_end-$time_start))
+    time_build_cost="$(($time_diff / 60)) minutes and $(($time_diff % 60)) seconds"
+
     # Report a build result of Yocto package
     # Let's do the build procedure of or skip the build procedure according to $BUILD_MODE
     if [[ $BUILD_MODE == 99 ]]; then
@@ -206,10 +214,10 @@ function pr-audit-build-yocto-run-queue(){
 
         # Let's report build result of source code
         if [[ $check_result == "success" ]]; then
-            message="Successfully  YOCTO build checker is passed. Commit number is '$input_commit'."
+            message="Yocto.build Successful in $time_build_cost. Commit number is '$input_commit'."
             cibot_report $TOKEN "success" "TAOS/pr-audit-build-yocto" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
         else
-            message="Oooops. YOCTO  build checker is failed. Resubmit the PR after fixing correctly. Commit number is $input_commit."
+            message="Yocto.build Failure after $time_build_cost. Commit number is $input_commit."
             cibot_report $TOKEN "failure" "TAOS/pr-audit-build-yocto" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
 
             export BUILD_TEST_FAIL=1


### PR DESCRIPTION
Fixed issue #466.

The build time is always PITA when the PRs are suddenly submitted.
This commit is to support a build time recorder to display a required time
to complete a build procedure whenever contributors submit a PRs.

**Changelog**
1. Added variables to check start and end time.
2. Updated the webhook message to inform contributors of an estimated build time
3. Applied the function to Ubuntu, Tizen, Yocoto, and Android module.

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>


---
