### PR TITLE
Build: Changed the display format of build modules

### DIFF
--- a/ci/taos/plugins-base/pr-audit-build-android.sh
+++ b/ci/taos/plugins-base/pr-audit-build-android.sh
@@ -174,7 +174,7 @@ function pr-audit-build-android-run-queue(){
     # Put a timer behind the build job to check an end time.
     time_end=$(date +"%s")
     time_diff=$(($time_end-$time_start))
-    time_build_cost="$(($time_diff / 60)) minutes and $(($time_diff % 60)) seconds"
+    time_build_cost="$(($time_diff / 60))m $(($time_diff % 60))s"
 
     # Report a test result
     # Let's run the build procedure. Or skip the build procedure according to $BUILD_MODE.

--- a/ci/taos/plugins-base/pr-audit-build-tizen.sh
+++ b/ci/taos/plugins-base/pr-audit-build-tizen.sh
@@ -119,7 +119,7 @@ function pr-audit-build-tizen-run-queue(){
     # Put a timer behind the build job to check an end time.
     time_end=$(date +"%s")
     time_diff=$(($time_end-$time_start))
-    time_build_cost="$(($time_diff / 60)) minutes and $(($time_diff % 60)) seconds"
+    time_build_cost="$(($time_diff / 60))m $(($time_diff % 60))s"
 
     # If the ./GBS-ROOT/ folder exists, let's remove this folder.
     # Note that this folder consume too many storage space (on average 9GiB).

--- a/ci/taos/plugins-base/pr-audit-build-ubuntu.sh
+++ b/ci/taos/plugins-base/pr-audit-build-ubuntu.sh
@@ -125,7 +125,7 @@ function pr-audit-build-ubuntu-run-queue(){
     # Put a timer behind the build job to check an end time.
     time_end=$(date +"%s")
     time_diff=$(($time_end-$time_start))
-    time_build_cost="$(($time_diff / 60)) minutes and $(($time_diff % 60)) seconds"
+    time_build_cost="$(($time_diff / 60))m $(($time_diff % 60))s"
 
 
     # report execution result

--- a/ci/taos/plugins-base/pr-audit-build-yocto.sh
+++ b/ci/taos/plugins-base/pr-audit-build-yocto.sh
@@ -169,7 +169,7 @@ function pr-audit-build-yocto-run-queue(){
     # Put a timer behind the build job to check an end time.
     time_end=$(date +"%s")
     time_diff=$(($time_end-$time_start))
-    time_build_cost="$(($time_diff / 60)) minutes and $(($time_diff % 60)) seconds"
+    time_build_cost="$(($time_diff / 60))m $(($time_diff % 60))s"
 
     # Report a build result of Yocto package
     # Let's do the build procedure of or skip the build procedure according to $BUILD_MODE


### PR DESCRIPTION
This commit is to change the output format of the existing build modules for readability.
After this PR, The build time information will be displayed on the screen.

* Before: 07 minutes and 24 seconds
* After : 07m 24s

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>


---