### PR TITLE
GBS Configuration Fix

### DIFF
--- a/packaging/.gbs.conf
+++ b/packaging/.gbs.conf
@@ -18,6 +18,9 @@ obs = obs.tizen
 repos = repo.unified, repo.base
 buildroot = ~/GBS-ROOT-Snapshot/
 
+# Install tizen.unified.conf at ~/ folder
+buildconf = ~/tizen.unified.conf
+
 [obs.tizen]
 # OBS API URL pointing to a remote OBS.
 url = https://api.tizen.org

--- a/packaging/tizen.unified.conf
+++ b/packaging/tizen.unified.conf
@@ -1,0 +1,389 @@
+%define _project Tizen:Unified
+
+### from Tizen:Base
+%define _repository standard
+
+Macros:
+%vendor obs://private/Tizen:Unified
+%_project Tizen:Unified
+
+### from Tizen:Base
+
+%_repository standard
+:Macros
+
+################################################################################
+# OBS Project config for Tizen:Base
+#
+# RE contacts:
+#
+#
+# vim: set syntax=spec:
+################################################################################
+
+Patterntype: rpm-md comps
+Release: <CI_CNT>.<B_CNT>
+Support: build
+Support: build-compare build-mkbaselibs
+# Support: rpmlint-mini rpmlint-tizen
+
+############################# conflicts resolution #############################
+
+Prefer: util-linux
+Prefer: mono-wcf
+Prefer: monodoc
+Prefer: mono-extras
+Prefer: mono-web
+Prefer: mono-data
+Prefer: mono-mvc
+Prefer: mono-winforms
+Prefer: mono-data-sqlite
+
+# Set a preference for ambiguous libs to use *-64bit libs
+#     *-64bit libs on 32bit build environment are required for .Net build (e.g., coreclr, corefx)
+#     But when building 64bit target, they could make 'have choice' error with original libs in 64bit repository.
+#     e.g., libstdc++ and libstdc++-64bit provides same libs. It's ambiguous to choose appropriate one.
+#     Owner : Jiyoung Yun (jy910.yun@samsung.com)
+Prefer: libgcc libstdc++ libunwind libuuid zlib libopenssl
+
+############################# base definition ###############################
+
+# %release_name and %tizen_full_version are used in platform/upstream/tizen-release
+
+Macros:
+%release_name Tizen5/Unified
+
+%tizen_version_major 5
+%tizen_version_minor 0
+%tizen_version_patch 0
+
+%tizen_version %{tizen_version_major}.%{tizen_version_minor}
+%tizen_full_version %{tizen_version}.%{tizen_version_patch}
+%tizen %tizen_version
+%vendor tizen
+%_vendor tizen
+%_with_tizen 1
+
+#### %__spec_check_pre exit 0
+#### %run_check_section 0
+
+%opensuse_bs 1
+%_default_patch_fuzz   2
+
+%_binary_payload w5T.xzdio
+:Macros
+
+
+############################# build config #####################################
+
+%define gcc_version 62
+Macros:
+%gcc_version 62
+:Macros
+
+########## targets ##########
+
+%ifarch i586
+Target: i686-tizen-linux
+%endif
+
+%ifarch armv7hl
+Target: armv7hl-tizen-linux
+%endif
+
+%ifarch armv7l
+Target: armv7l-tizen-linux
+%endif
+
+%ifarch aarch64
+Target: aarch64-tizen-linux
+%endif
+
+########## cross build ##########
+
+%define build_hostarch x86_64
+Macros:
+%build_hostarch x86_64
+:Macros
+
+%ifarch %arm armv7l aarch64
+Hostarch: x86_64
+# cross build support for the build hosts
+Preinstall: qemu-linux-user-%{build_hostarch}-cross
+Runscripts: qemu-linux-user-%{build_hostarch}-cross
+Keep: qemu-linux-user-%{build_hostarch}-cross
+Macros:
+%qemu_user_space_build 1
+:Macros
+%endif
+
+%ifarch armv7l
+Preinstall: qemu-accel-%{build_hostarch}-armv7l
+Runscripts: qemu-accel-%{build_hostarch}-armv7l
+Preinstall: libmount libblkid libuuid
+%endif
+
+%ifarch aarch64
+Preinstall: qemu-accel-%{build_hostarch}-aarch64
+Runscripts: qemu-accel-%{build_hostarch}-aarch64
+Preinstall: libmount libblkid libuuid
+%endif # aarch64
+
+Substitute: python-accel-armv7l-cross-arm python-accel-%{build_hostarch}-armv7l
+Substitute: python-accel-aarch64-cross-aarch64 python-accel-%{build_hostarch}-aarch64
+
+Substitute: clang-accel-armv7l-cross-arm clang-accel-%{build_hostarch}-armv7l
+Substitute: clang-accel-aarch64-cross-aarch64 clang-accel-%{build_hostarch}-aarch64
+
+########## exports for different architectures ##########
+
+ExportFilter: \.armv7l\.rpm$ armv7l
+ExportFilter: \.aarch64\.rpm$ aarch64
+ExportFilter: \.i586\.rpm$ i586
+ExportFilter: \.x86_64\.rpm$ x86_64
+
+########## buildroot config ##########
+
+Preinstall: setup filesystem
+RunScripts: setup
+
+Preinstall: bash bzip2 coreutils diffutils grep rpm
+Preinstall: glibc libacl libattr
+Preinstall: libcap
+Preinstall: libgcc
+Preinstall: libpopt sed tar zlib
+Preinstall: libncurses libreadline
+Preinstall: libelf libbz2
+Preinstall: liblzma
+Preinstall: nss nspr libfreebl3 libsoftokn3
+Preinstall: libmagic
+Preinstall: liblua
+Preinstall: smack libsmack libxml2 libmagic  libmagic-data
+Preinstall: libsqlite
+#Preinstall: rpm-security-plugin
+Preinstall: util-linux util-linux-su
+
+VMinstall: perl libmount libblkid libext2fs libuuid  grep libpcre util-linux libsmartcols procps-ng
+
+Required: binutils gcc glibc rpm-build libtool
+Required: gcc-c++
+
+Support: glibc-locale
+Support: perl
+Support: hostname
+Support: cpio findutils
+Support: file findutils zlib bzip2
+Support: gzip hostname net-tools
+Support: make  patch sed  gawk tar grep coreutils pkg-config
+Support: m4  tzdata
+Support: util-linux
+Support: less
+Support: which  elfutils
+Support: update-alternatives
+Support: libstdc++-devel
+Support: cpp
+Support: libatomic
+Support: libgomp
+Support: libitm
+
+Keep: libstdc++-devel
+Keep: cpp gcc libstdc++
+Keep: pam
+Keep: binutils cpp  libmagic-data file findutils gawk gcc  gcc-c++
+Keep: gdbm gzip libada libunwind  glibc-devel libpcre xz-lzma-compat
+Keep: make  gmp libcap groff cpio
+Keep: patch rpm-build  nss nspr elfutils python grep libgcc gcc-c++
+Keep: kernel-headers  perl-libs perl
+Keep: pkgconfig glib2 tizen-rpm-config
+Keep: libmpc libmpfr libppl libgmp libppl_c
+Keep: libcloog libppl libgmpxx
+Keep: nss-softokn-freebl libmagic libmagic-data
+Keep: setup
+Keep: update-alternatives
+Keep: cpp
+Keep: gcc-c++
+Keep: libatomic
+Keep: libgomp
+Keep: libitm
+
+Substitute: gettext gettext-tools
+
+%ifarch x86_64
+Substitute: glibc-devel-32bit glibc-devel-32bit glibc-32bit
+Substitute: libgcc_s1-32bit libgcc-32bit
+%else
+Substitute: glibc-devel-32bit
+%endif
+
+########## compilation flags ##########
+%define __global_cflags -O2 -g2 -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector -Wformat-security -fmessage-length=0 -Wl,--as-needed
+
+Optflags: armv7l %{__global_cflags} --param=ssp-buffer-size=4 -march=armv7-a -mtune=cortex-a8 -mlittle-endian -mfpu=neon -mfloat-abi=softfp -mthumb -Wp,-D__SOFTFP__ -Wl,-O1 -Wl,--hash-style=gnu -Wa,-mimplicit-it=thumb
+Optflags: aarch64 %{__global_cflags} -feliminate-unused-debug-types -Wformat -march=armv8-a+fp+simd+crc+crypto -mtune=cortex-a57.cortex-a53
+Optflags: i686 %{__global_cflags} -feliminate-unused-debug-types --param=ssp-buffer-size=4 -fdiagnostics-color=never -m32 -march=i686 -mtune=i686 -msse4.2 -mfpmath=sse -fasynchronous-unwind-tables -fno-omit-frame-pointer
+Optflags: x86_64 %{__global_cflags} -feliminate-unused-debug-types --param=ssp-buffer-size=4 -fdiagnostics-color=never -m64 -march=nehalem -msse4.2 -mfpmath=sse -fasynchronous-unwind-tables -fno-omit-frame-pointer
+### from Tizen:Unified
+%define _repository standard
+
+Macros:
+
+%distribution Tizen:Unified
+%_project Tizen:Unified
+
+### from Tizen:Unified
+
+%_repository standard
+:Macros
+
+################################################################################
+# OBS Project config for Tizen:Unified
+#
+# vim: set syntax=spec:
+################################################################################
+
+############################# conflicts resolution #############################
+
+FileProvides: /usr/sbin/groupadd shadow-utils
+Prefer: bluetooth-tools-no-firmware
+
+############################# profile definition ###############################
+
+%define _with_tizen 1
+
+# For classifying debug/release mode
+Macros:
+%tizen_build_devel_mode 1
+:Macros
+
+# %release_name and %tizen_full_version are used in platform/upstream/tizen-release
+
+Macros:
+%release_name Tizen5/Unified
+
+%tizen_version_major 5
+%tizen_version_minor 0
+%tizen_version_patch 0
+
+%tizen_version %{tizen_version_major}.%{tizen_version_minor}
+%tizen_full_version %{tizen_version}.%{tizen_version_patch}
+%tizen %tizen_version
+%vendor tizen
+%_vendor tizen
+%_with_tizen 1
+
+#### %__spec_check_pre exit 0
+#### %run_check_section 0
+%opensuse_bs 1
+%_default_patch_fuzz   2
+:Macros
+
+########## mesa activation / coregl ##########
+
+%define _with_mesa 1
+Macros:
+%_with_mesa 1
+:Macros
+
+Substitute: mesa-devel pkgconfig(glesv2)
+Substitute: pkgconfig(gles20)  pkgconfig(egl) pkgconfig(glesv2)
+Substitute: pkgconfig(gles11)  pkgconfig(egl) pkgconfig(glesv1) pkgconfig(gl)
+
+Prefer: coregl coregl-devel
+Prefer: libwayland-egl libwayland-egl-devel
+#libelementary.so (upstream, tizen-only ) so add below Prefer. Requested by EFL team. 
+Prefer: elementary
+
+########## WAYLAND #########
+
+%define _with_wayland 1
+Macros:
+%_with_wayland 1
+:Macros
+
+########## RDP flag ##########
+
+# enable/disable RDP (remote desktop protocol) for wayland
+# flag: _with_rdp, used in repositories
+# Affects: weston, freerdp
+# Owner: Manuel <manuel.bachmann@open.eurogiciel.org>
+
+############################# target repositories #############################
+
+%if "%_repository" == "standard"
+
+Prefer: mesa libgbm
+Substitute: mesa-libGLESv2 coregl
+Substitute: mesa-libEGL coregl
+
+%define _with_rdp 1
+Macros:
+%_with_rdp 1
+:Macros
+
+%endif
+
+############################# emulator repositories ############################
+
+%if "%_repository" == "emulator"
+
+Prefer: libgbm
+Prefer: emulator-yagl emulator-yagl-devel
+
+%define _with_emulator 1
+Macros:
+%_with_emulator 1
+:Macros
+
+%endif
+
+############################# misc config flags ################################
+########## USAGE ##########
+#
+# IMPORTANT: please follow the following rules when playing with flags
+# ********************************************************************
+#
+# In spec file, call %bcond_with macro at the beginning and test with %with:
+# -------------------------
+# | %bcond_with myfeature
+# | [...]
+# | %if %{with myfeature}
+# | [...]
+# | %endif
+# | [...]
+# -------------------------
+#
+# To activate an option, use:
+# -------------------------
+# | %define _with_myfeature 1
+# | Macros:
+# | %_with_myfeature 1
+# | :Macros
+# -------------------------
+#
+# To disable an option, DON'T set the values to 0, as the option would still be defined
+# but simply comment the lines: this will undefine the option.
+# -------------------------
+# | #%define _with_myfeature 1
+# | #Macros:
+# | #%_with_myfeature 1
+# | #:Macros
+# -------------------------
+#
+# More information here:
+# https://en.opensuse.org/openSUSE:Build_Service_prjconf#.25bcond
+#
+
+########## flags ##########
+
+# Activate introspection
+# This is needed on GuPNP to build Rygel correctly in IVI
+# Impacts potentially packages that use gobject-introspection
+# Owner: Mikko <mikko.ylinen@intel.com>
+
+Macros:
+%_with_introspection 1
+:Macros
+
+############################# other config #####################################
+# derived from Tizen:Base
+################################################################################


### PR DESCRIPTION
The previous gbs.conf was not importing build conf of Tizen:Unified.
With more complex packaging, this has started creating build fails.

The file is imported from Tizen official build conf from scm/meta/build-config.git

We need to apply this change to the server to address
https://github.com/nnsuite/nnstreamer/issues/1235

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>


**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped
