### PR TITLE
Tizen: update the incorrect repo statement in .gbs.conf

### DIFF
--- a/packaging/.gbs.conf
+++ b/packaging/.gbs.conf
@@ -1,4 +1,4 @@
-# Please, rename the "gbs.conf.20180501" file. 
+# Please, rename the "gbs.conf.20180501" file.
 # Note that the ".gbs.conf" file has to be located in ~/ folder.
 #
 [general]
@@ -11,18 +11,20 @@ workdir = .
 
 [profile.tizen]
 # Common authentication info for whole profile
-user = <WRITE_YOUR_TIZEN_ID>
-passwd = <WRITE_YOUR_PASSOWRD_HERE>
+user = {TIZEN_ID}
+passwd = {TIZEN_PASSWORD}
 obs = obs.tizen
 
-repos = repo.unified, repo.base
+# https://source.tizen.org/documentation/developer-guide/environment-setup
+# Note that a buildconf file of the last repo (e.g., /var/tmp/{USER}-gbs/tizen.of) is used by default.
+repos = repo.aic, repo.base, repo.unified
 buildroot = ~/GBS-ROOT-Snapshot/
 
 [obs.tizen]
 # OBS API URL pointing to a remote OBS.
 url = https://api.tizen.org
 
-# in case that one of the Tizen rpm repositories has issues, replace "latest" with an out-of-date stable folder name.
+# In case that one of the Tizen rpm repositories has issues, replace "latest" with an out-of-date stable folder name.
 # https://github.com/01org/gbs/blob/master/docs/GBS.rst#34-shell-style-variable-references
 # ver_base=tizen-base_20180427.1
 # ver_unified=tizen-unified_20180504.2
@@ -36,7 +38,6 @@ url = http://download.tizen.org/snapshots/tizen/base/latest/repos/standard/packa
 url = http://download.tizen.org/snapshots/tizen/unified/latest/repos/standard/packages/
 # url = http://git.bot.sec:npu28xx@165.213.149.200/download/public_mirror/tizen/unified/latest/repos/standard/packages/
 
-
-
-
+[repo.aic]
+url = http://download.tizen.org/live/devel:/AIC:/Tizen:/5.0:/nnsuite/standard/
 


### PR DESCRIPTION
This commit is to fix incorrect statement in .gbs.conf file.
If we write multiple repositories in varaible 'repos',
the last repo is finally overwritten.

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>


---