### PR TITLE
[nnstreamer/apptest] script to build examples

### DIFF
--- a/ci/taos/plugins-staging/pr-audit-nnstreamer-ubuntu-apptest.sh
+++ b/ci/taos/plugins-staging/pr-audit-nnstreamer-ubuntu-apptest.sh
@@ -114,10 +114,20 @@ function pr-audit-nnstreamer-ubuntu-apptest-run-queue() {
     # Build a source code
     meson --prefix=${NNST_ROOT} --sysconfdir=${NNST_ROOT} --libdir=lib --bindir=bin --includedir=include build
 
-    # Install a nnstreamer library and examples
+    # Install a nnstreamer library
     ninja -C build install
 
+    # Clone the nnstreamer-example repository
+    git clone https://github.com/nnsuite/nnstreamer-example.git exam-tmp
+
+    # Build and install nnstreamer examples
+    cd exam-tmp
+    meson --prefix=${NNST_ROOT} --sysconfdir=${NNST_ROOT} --libdir=lib --bindir=bin --includedir=include build
+    ninja -C build install
+    cd ..
+
     # After installation, binary files are installed to 'bin' folder.
+    rm -rf exam-tmp
     rm -rf build
     cd bin
 


### PR DESCRIPTION
To run app-test in nnstreamer repo, clone nnstreamer-examples and install the examples.

**Changelogs**
* Version 2:
  - update the description

* Version 1:
  - add script to build the nnstreamer examples

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
