### PR TITLE
Doxygen: Fixed incorrect project name

### DIFF
--- a/ci/Doxyfile
+++ b/ci/Doxyfile
@@ -32,7 +32,7 @@ DOXYFILE_ENCODING      = UTF-8
 # title of most generated pages and in a few other places.
 # The default value is: My Project.
 
-PROJECT_NAME           = "AuDri Project"
+PROJECT_NAME           = "Your Project"
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. This
 # could be handy for archiving the generated documentation or if some version


### PR DESCRIPTION
This commit is to replace the existing project name with
an appropriate project name as a default template.

Signed-off-by: junghan <junghan@skku.edu>


---
