### PR TITLE
[gcov] Add a procedure for generating a 'code coverage' badge

### DIFF
--- a/ci/gcov/coverage-generator.sh
+++ b/ci/gcov/coverage-generator.sh
@@ -68,6 +68,9 @@ if [[ -d ../gcov_html ]]; then
 fi
 mkdir -p ../gcov_html
 mv -f usr/share/nnstreamer/unittest/result/* ../gcov_html
+if [[ -f ../gcov_html/index.html ]]; then
+    ../badge/gen_badge.py codecoverage ../gcov_html/index.html ../badge/codecoverage.svg
+fi
 cd -
 
 # Remove unused folder. 


### PR DESCRIPTION
This patch adds a new procedure that generates a github badge for representing 'code coverage'.

Signed-off-by: Wook Song <wook16.song@samsung.com>

#### Changelog ####
- V2: Add an indentation

#### Expected Results ####
https://github.com/wooksong/nnstreamer-ros/tree/add-readme