### PR TITLE
Changed a extension format of log files (.log to .txt)

### DIFF
--- a/ci/taos/checker-pr-gateway.sh
+++ b/ci/taos/checker-pr-gateway.sh
@@ -189,13 +189,13 @@ declare -a checker_logfile_list
 # Ready a checker: format
 checker_cmd_list+=("./checker-pr-format-async.sh")
 checker_name_list+=("format")
-checker_logfile_list+=("${dir_ci}/${dir_commit}/checker-pr-format.log")
+checker_logfile_list+=("${dir_ci}/${dir_commit}/pr-format-group.txt")
 echo -e "[DEBUG] Added ${checker_name_list[-1]} checker"
 
 # Ready a checker: audit
 checker_cmd_list+=("./checker-pr-audit-async.sh")
 checker_name_list+=("audit")
-checker_logfile_list+=("${dir_ci}/${dir_commit}/checker-pr-audit.log")
+checker_logfile_list+=("${dir_ci}/${dir_commit}/pr-aduit-group.txt")
 echo -e "[DEBUG] Added ${checker_name_list[-1]} checker"
 
 # Run all the checkers

--- a/ci/taos/plugins-staging/pr-audit-nnstreamer-ubuntu-apptest.sh
+++ b/ci/taos/plugins-staging/pr-audit-nnstreamer-ubuntu-apptest.sh
@@ -226,7 +226,7 @@ function pr-audit-nnstreamer-ubuntu-apptest-run-queue() {
         cibot_report $TOKEN "failure" "TAOS/pr-audit-nnstreamer-apptest" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
 
         # Comment a hint on failed PR to author.
-        message=":octocat: **cibot**: $user_id, apptest could not be completed. To find out the reasons, please go to ${CISERVER}/${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/checker-pr-audit.txt"
+        message=":octocat: **cibot**: $user_id, apptest could not be completed. To find out the reasons, please go to ${CISERVER}/${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/pr-aduit-group.txt"
         cibot_comment $TOKEN "$message" "$GITHUB_WEBHOOK_API/issues/$input_pr/comments"
 
         return ${result}
@@ -439,7 +439,7 @@ function pr-audit-nnstreamer-ubuntu-apptest-run-queue() {
         cibot_report $TOKEN "failure" "TAOS/pr-audit-nnstreamer-apptest" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
 
         # comment a hint why a submitted PR is failed.
-        message=":octocat: **cibot**: $user_id, apptest could not be completed. To find out the reasons, please go to ${CISERVER}/${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/checker-pr-audit.log"
+        message=":octocat: **cibot**: $user_id, apptest could not be completed. To find out the reasons, please go to ${CISERVER}/${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/pr-aduit-group.txt"
         cibot_comment $TOKEN "$message" "$GITHUB_WEBHOOK_API/issues/$input_pr/comments"
     fi
 }


### PR DESCRIPTION
This commit is to replace .log with .txt in order to improve compatibility
and readability when press the log files among the browsers. The www-data
of Apache web-server executes the scripts based on the configuration file
of Apache httpd daemon. In case of text files, let's use .txt format instead
of the .log file extension.

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>


---