### PR TITLE
Out-of-PR Killer runs based on synchronous technique

### DIFF
--- a/ci/taos/checker-pr-gateway.sh
+++ b/ci/taos/checker-pr-gateway.sh
@@ -160,8 +160,12 @@ function run_all_checkers(){
     echo -e "[DEBUG] ${cmd_list[$i]} $checker_args "                     | tee -a $logfile
     echo -e "[DEBUG] Starting a ${name_list[$i]} checker... "            | tee -a $logfile
     # Run checker
+    # Currently, there are two checkers such as format and audit. The current format checker is not heavy.
+    # But, if the format checker needs more times to complete the modules, please consider introduce
+    # to run the checkers asynchronously with the background command (e.g., command | tee -a $logfile &).
+    # Note that you must modify the Out-of-PR (OOP) killer because OOP killer depends on synchronous method.
     pushd ./taos/
-    ${cmd_list[$i]} $checker_args                                        | tee -a $logfile &
+    ${cmd_list[$i]} $checker_args                                        | tee -a $logfile
     local pid=$!
     popd
     echo -e "[DEBUG] Running..."                                         | tee -a $logfile


### PR DESCRIPTION
Fixed issue https://github.com/nnsuite/nnstreamer/pull/1231

This commit is to return the exeuction method from asynchrnous (recently)
to synchronous method because the format group still not heavy.

Let's execute the checkers in order synchronously.
1. Run each checker in order: format checker and audit checker
2. Run policy between two methods
  - Method1: If a checker is failed,
             the check procedure will be stopped without starting a next checker.
  - Method2: Although a checker is failed,
             a next checker will be started continually.

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>


---