### PR TITLE
[app-test] fix invalid conf file

### DIFF
--- a/ci/taos/plugins-staging/pr-audit-nnstreamer-ubuntu-apptest.sh
+++ b/ci/taos/plugins-staging/pr-audit-nnstreamer-ubuntu-apptest.sh
@@ -142,10 +142,7 @@ function pr-audit-nnstreamer-ubuntu-apptest-run-queue() {
     echo -e "[DEBUG] GST_PLUGIN_PATH is '$GST_PLUGIN_PATH'"
 
     # nnstreamer env variables and include paths
-    export NNSTREAMER_CONF=$NNST_ROOT
-    export NNSTREAMER_FILTERS=$NNST_ROOT/lib/nnstreamer/filters
-    export NNSTREAMER_DECODERS=$NNST_ROOT/lib/nnstreamer/decoders
-    export NNSTREAMER_CUSTOMFILTERS=$NNST_ROOT/lib/nnstreamer/customfilters
+    export NNSTREAMER_CONF=$NNST_ROOT/nnstreamer.ini
     export C_INCLUDE_PATH=$C_INCLUDE_PATH:$NNST_ROOT/include
     export CPLUS_INCLUDE_PATH=$CPLUS_INCLUDE_PATH:$NNST_ROOT/include
 


### PR DESCRIPTION
set valid conf file path for nnstreamer

**Changelogs**
* Version 2:
  - remove unnecessary env variables to get sub-plugins

* Version 1:
  - fix invalid conf path

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
