### PR TITLE
[nnstreamer/apptest] Added dependency: python-numpy & python3-numpy

### DIFF
--- a/ci/taos/webapp/install-packages-nnstreamer.sh
+++ b/ci/taos/webapp/install-packages-nnstreamer.sh
@@ -52,5 +52,6 @@ echo -e "########## for CI-system: Installing python packages for nnstreaemr app
 sudo apt -y install python-gi python3-gi  
 sudo apt -y install python-gst-1.0 python3-gst-1.0
 sudo apt -y install python-gst-1.0-dbg python3-gst-1.0-dbg
+sudo apt -y install python-numpy python3-numpy
 
 echo -e "[DEBUG] Required packages are successfully installed...."


### PR DESCRIPTION
This commit is to append 'python-numpy' & 'python3-numpy' to installed packages

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped

Signed-off-by: Dongju Chae <dongju.chae@samsung.com>