### PR TITLE
Updated CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,7 +9,7 @@
 *                @leemgs @myungjoo
 
 # For /ci/, reviewers are limited to those who understand continuous integration (CI)
-/ci/             @myungjoo @jijoongmoon @leemgs @again4you @wooksong @jaeyun-jung @helloahn @kparichay
+/ci/             @myungjoo @jijoongmoon @leemgs @again4you @wooksong @jaeyun-jung @helloahn @kparichay @dongju-chae
 
 # For /packaging/, reviewers are limited to those who have some RPM packaging experiences
 /packaging/      @myungjoo @leemgs @again4you @wooksong


### PR DESCRIPTION
This commit is to add @dongju-chae into the automated reviewer list.

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>


---