### PR TITLE
[Base/Build/Android] Remove the step for patching Non-Tizen

### DIFF
--- a/ci/taos/plugins-base/pr-postbuild-build-android.sh
+++ b/ci/taos/plugins-base/pr-postbuild-build-android.sh
@@ -131,7 +131,6 @@ function pr-postbuild-build-android-run-queue(){
     check_cmd_dep curl
     check_cmd_dep ndk-build
     check_cmd_dep sed
-    check_cmd_dep patch
 
     echo "[DEBUG] starting TAOS/pr-postbuild-build-android facility"
 
@@ -158,12 +157,6 @@ function pr-postbuild-build-android-run-queue(){
 
         # NNStreamer root directory for build.
         export NNSTREAMER_ROOT=$(pwd)
-
-        # First perform a dry run to verify that the patch can be applied (performing a reverse patch apply should fail)
-        if ! patch -R --dry-run -sfp1 -i $NNSTREAMER_ROOT/packaging/non_tizen_build.patch; then
-            # Apply the patch for Android build
-            patch -sfp1 -i $NNSTREAMER_ROOT/packaging/non_tizen_build.patch
-        fi
 
         # Options:
         # a. TODO: A trigger option is to be used as PR number and PR time (a trick)
@@ -246,9 +239,6 @@ function pr-postbuild-build-android-run-queue(){
 
         # Remove build directory.
         rm -rf build_android_lib
-
-        # Undo the applied the patch for Android build
-        patch -R -sfp1 -i $NNSTREAMER_ROOT/packaging/non_tizen_build.patch
     fi
     echo "[DEBUG] The result value is '$result'."
 


### PR DESCRIPTION
Related to https://github.com/nnsuite/nnstreamer/pull/1827
See also https://github.com/nnsuite/nnstreamer/pull/1824#issuecomment-545848382

According to the recent modification in the build script for NNS Android API Library, this patch removes the step for patching C-API header to use it on non-Tizen platform.

Signed-off-by: Wook Song <wook16.song@samsung.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped