### PR TITLE
[Doxygen-Tag] Boilerplate may start with /*

### DIFF
--- a/ci/taos/plugins-good/pr-prebuild-doxygen-tag.sh
+++ b/ci/taos/plugins-good/pr-prebuild-doxygen-tag.sh
@@ -131,7 +131,7 @@ function pr-prebuild-doxygen-tag(){
                             # Check a comment statement that begins with '/*'.
                             # Note that doxygen does not recognize a comment  statement that start with '/*'.
                             # Let's skip the doxygen tag inspection such as "/**" in case of a single line comment.
-                            if [[ $line =~ "/*" && $line != *"/**"*  && ( $line != *"*/"  || $line =~ "@" ) ]]; then
+                            if [[ $line =~ "/*" && $line != *"/**"*  && ( $line != *"*/"  || $line =~ "@" ) && ( $idx != 1 ) ]]; then
                                 echo "[ERROR] File name: $curr_file, $idx line, Doxygen or multi line comments should begin with /**"
                                 check_result="failure"
                                 global_check_result="failure"


### PR DESCRIPTION
Although it is a multi-line comment, do not make errors
for boilerplates even if it starts with /*.
Assume that comments starting at line 1 is a boilerplate.

This is for
https://github.com/nnsuite/nnstreamer/pull/1841
, which is required by Tizen API/SDK post-processing.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

