### PR TITLE
webapp: Added PR handler to handle incorrect report of CI module

### DIFF
--- a/ci/taos/webapp/pr-handler-proceed.php
+++ b/ci/taos/webapp/pr-handler-proceed.php
@@ -1,0 +1,174 @@
+<?php
+
+
+/**
+ * Copyright (c) 2018 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+/**
+ * @file   monitor.php
+ * @author Geunsik Lim <geunsik.lim@samsung.com>
+ * @param  None
+ *
+ */
+
+
+/**
+ * @brief Get a client IP address
+ *
+ * Get IP address that a system administrator uses.
+ */
+function get_client_ip()
+{
+     $ipaddress = '';
+     if (getenv('HTTP_CLIENT_IP'))
+         $ipaddress = getenv('HTTP_CLIENT_IP');
+     else if(getenv('HTTP_X_FORWARDED_FOR'))
+         $ipaddress = getenv('HTTP_X_FORWARDED_FOR');
+     else if(getenv('HTTP_X_FORWARDED'))
+         $ipaddress = getenv('HTTP_X_FORWARDED');
+     else if(getenv('HTTP_FORWARDED_FOR'))
+         $ipaddress = getenv('HTTP_FORWARDED_FOR');
+     else if(getenv('HTTP_FORWARDED'))
+         $ipaddress = getenv('HTTP_FORWARDED');
+     else if(getenv('REMOTE_ADDR'))
+         $ipaddress = getenv('REMOTE_ADDR');
+     else
+         $ipaddress = 'UNKNOWN';
+     return $ipaddress;
+}
+
+// Get a input date from HTML FORM tag.
+$id               = $_POST['id'];
+$password         = $_POST['pass'];
+$input_module     = $_POST['cimodule'];
+$input_msg_comment= ":octocat:".$_POST['message'];
+$input_msg_report = ":octocat:".$_POST['message'];
+$input_status     = $_POST['status'];
+$number_commit    = $_POST['commit'];
+$number_pr        = $_POST['pr'];
+
+function display_input(){
+    echo ("id: $id <br>");
+    echo ("password: $password <br>");
+    echo ("input_module: $input_module <br>");
+    echo ("input_msg_comment: $input_msg_comment <br>");
+    echo ("input_msg_report: $input_msg_report <br>");
+    echo ("input_status: $input_status <br>");
+    echo ("commit number: $number_commit <br>");
+    echo ("pr number: $number_pr <br>");
+}
+
+// Read a JSON file.
+$string = file_get_contents("../config/config-webhook.json");
+$json_config = json_decode($string);
+
+// Get id and passowrd from json file. The prefix 'ba' means "Broken Arrow".
+$ba_id = $json_config->broken_arrow->id;
+$ba_password = $json_config->broken_arrow->pass;
+$ba_ipaddress = $json_config->broken_arrow->ip;
+
+// Security: Check if a IP address of a system administrator is equal to an allowed IP address.
+$ipaddress = get_client_ip();
+if ( $ba_ipaddress != "" && $ba_ipaddress != $ipaddress ) {
+   echo ("Unable to do the PR handler.<br>Specify IP address in the configuration file.");
+   exit(1);
+}
+
+// Check if id and password are correctly typed.
+if ($id == "" || $password == "") {
+    echo ("<br>
+        Sorry, We can not do your request.<br>Please type a ID and Password. <br>
+        <br>
+        <button onclick=\"goBack()\">Go Back</button>
+        <script>
+         function goBack() {
+         window.history.back();
+        }
+        </script>");
+    exit(1);
+}
+
+if ( $id == $ba_id && $password == $ba_password) {
+    echo ("ID and Pasword is correct.<br>");
+    ?>
+        <script>
+          var ba_message="[NOTICE] The CI system changes the status of the specified CI module on the PR.";
+          ba_message+="the comment will be displayed on the PR.";
+          window.alert(ba_message);
+        </script>
+    <?php
+    // Run the the PR comment handler. The number of argument is 2.
+    if ( $input_msg_comment && $number_pr ) {
+        echo ("Running the PR comment handler ...<br>");
+        $cmd = "./pr-handler-runner.sh \"$input_msg_comment\" \"$number_pr\"";
+        $output = array();
+        try{
+            flush();
+            echo ("Updating the PR status.<br>");
+            echo ("shell_exec(\"$cmd\")<br>");
+            exec($cmd, $output);
+            //system($cmd, $output);
+        }
+        catch(Exception $e){
+            echo "Caught exception: ",$e->getMessage(),"\nUnable to change the status of the PR....\n";
+        }
+        //foreach ($output as $line) {
+        //    print "[DEBUG] $line<br>";
+        //}
+     }
+
+    // Run the the PR report handler. The number of arguments is 4.
+    else if ( $input_status && $input_module && $input_msg_report && $number_commit ) {
+        echo ("Running the PR comment handler ...<br>");
+        $cmd = "./pr-handler-runner.sh \"$input_status\" \"$input_module\"  \"$input_msg_report\" \"$number_commit\"";
+        $output = array();
+        try{
+            flush();
+            echo ("Updating the PR status.<br>");
+            echo ("shell_exec(\"$cmd\")<br>");
+            exec($cmd, $output);
+            //system($cmd, $output);
+        }
+        catch(Exception $e){
+            echo "Caught exception: ",$e->getMessage(),"\nUnable to change the status of the PR....\n";
+        }
+        foreach ($output as $line) {
+            print "[DEBUG] $line<br>";
+        }
+    }
+    else {
+    echo ("Oooops. Your input data do not satisfied with the requirement of the handlders.<br>");
+    exit(1);
+    }
+  
+    echo ("<br>
+        It's okay, The PR handler completed your request.<br>
+        <br>
+        <button onclick=\"goBack()\">Go Back</button>
+        <script>
+         function goBack() {
+         window.history.back();
+        }
+        </script>");
+
+}
+else {
+    echo ("Oooops. ID and password is incorrect.<br>");
+    echo ("Please check it.<br>");
+}
+
+
+?>
+

--- a/ci/taos/webapp/pr-handler-runner.sh
+++ b/ci/taos/webapp/pr-handler-runner.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+
+source ../config/config-environment.sh
+source ../common/api_collection.sh
+
+# TODO: Enhance the security of the handler.
+
+# if # of arguments is 2, run the comment handler
+args=$#
+echo -e "[DEBUG] The number of arguments is $args."
+echo -e "[DEBUG] command is ($0 $1 $2 $3 $4.)"
+if [[ $args == 2 ]]; then
+    echo -e "[DEBUG] setting parameters for the PR comment handler..."
+    input_msg_comment="$1"
+    input_pr="$2"
+    echo -e "[DEBUG] *Token           : ******"
+    echo -e "[DEBUG] *Message(report) : $input_msg_report"
+    echo -e "[DEBUG] *Message(comment): $input_msg_comment"
+    echo -e "[DEBUG] *API   : $GITHUB_WEBHOOK_API"
+    echo -e "[DEBUG] *PR    : $input_pr"
+# if # of arguments is 4, run the report handler
+elif [[ $args == 4 ]]; then
+    echo -e "[DEBUG] setting parameters for the PR report handler..."
+    input_status="$1"
+    input_cimodule="$2"
+    input_msg_report="$3"
+    input_commit="$4"
+    echo -e "[DEBUG] *Token           : ******"
+    echo -e "[DEBUG] *Status: $input_status"
+    echo -e "[DEBUG] *CI module: $input_cimodule"
+    echo -e "[DEBUG] *Message(report) : $input_msg_report"
+    echo -e "[DEBUG] *Message(comment): $input_msg_comment"
+    echo -e "[DEBUG] *CI Server: $CISERVER"
+    echo -e "[DEBUG] *API   : $GITHUB_WEBHOOK_API"
+    echo -e "[DEBUG] *commit: $input_commit"
+else
+    echo -e "Ooops. Please check the number of the arguments."
+fi
+
+
+
+if [[ $input_msg_report ]]; then
+    echo -e '[DEBUG] cibot_report $TOKEN "$input_status" "$input_cimodule" "$input_msg_report" "$CISERVER" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"'
+    cibot_report $TOKEN "$input_status" "$input_cimodule" "$input_msg_report" "$CISERVER" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+else
+    echo -e "[WARN] The system does not run the cibot_report() because the variable input_msg_report is empty."
+fi
+
+if [[ $input_msg_comment ]]; then
+    cibot_comment $TOKEN "$input_msg_comment" "$GITHUB_WEBHOOK_API/issues/$input_pr/comments"
+else
+    echo -e "[WARN] The system does not run the cibot_comment() because the variable input_msg_comment is empty."
+fi

--- a/ci/taos/webapp/pr-handler.php
+++ b/ci/taos/webapp/pr-handler.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Copyright (c) 2018 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+##
+# @file   pr-handler.php
+# @author Geunsik Lim <geunsik.lim@samsung.com>
+# @brief  A handler to control the status of the PRs manually
+# @param  None
+#
+
+?>
+ 
+<html>
+<head>
+<title>PR Handler:Report and Comment</title>
+</head>
+<body>
+<font size=6>PR Report Handler: </font> <br>
+<br>
+
+<form action="pr-handler-proceed.php" method="post">
+<table border=0>
+<tr>
+<td><img src=./circle.png with=20 height=20>ID</td><td><input type="text" name="id"><br></td>
+</tr>
+<tr>
+<td><img src=./circle.png with=20 height=20>Password</td><td><input type="password" name="pass"><br></td>
+</tr>
+<tr>
+<td><img src=./circle.png width=20 height=20>CI module name</td><td><input type="text" size=40 name="cimodule" value="TAOS/pr-postbuild-build-tizen-aarch64"><br></td>
+</tr>
+<tr>
+<td><img src=./circle.png width=20 height=20>commit number</td><td><input type="text" size=40 name="commit" value="1f6ec74036ea816cc15659a311ac82532b0dcdd3"><br></td>
+</tr>
+<tr>
+<td><img src=./circle.png width=20 height=20>Comment</td><td><textarea rows=6 cols=60  name="message" value="">[TEST] The current status is chaged by a web-based PR handler.</textarea><br></td>
+</tr>
+<tr>
+<td><img src=./circle.png width=20 height=20>Status</td><td>
+<select name="status" >
+  <option value="success">success</option>
+  <option value="failure">failure</option>
+</select>
+<br></td>
+</tr>
+<tr>
+<td>
+<br>
+<input type="submit" onClick="return ConfirmCmd()" value="Click"></td>
+<td></td>
+</tr>
+</form>
+</table
+<br>
+<br>
+<hr>
+<font size=6>PR Comment Handler: </font> <br>
+<br>
+
+<form action="pr-handler-proceed.php" method="post">
+<table border=0>
+<tr>
+<td><img src=./circle.png with=20 height=20>ID</td><td><input type="text" name="id"><br></td>
+</tr>
+<tr>
+<td><img src=./circle.png with=20 height=20>Password</td><td><input type="password" name="pass"><br></td>
+</tr>
+<tr>
+<td><img src=./circle.png width=20 height=20>PR number</td><td><input type="text" size=10 name="pr" value="1866"><br></td>
+</tr>
+<tr>
+<td><img src=./circle.png width=20 height=20>Comment</td><td><textarea rows=6 cols=60  name="message" value="">[TEST] This comment is just test message.</textarea><br></td>
+</tr>
+<tr>
+<td>
+<br>
+<input type="submit" onClick="return ConfirmCmd()" value="Click"></td>
+<td></td>
+</tr>
+</table>
+</form>
+</body>
+</html>
+
+


### PR DESCRIPTION
Fixed issue #557

This commit is to append web-based PR handler in order that
the reviewers directly pass the execution result of the CI modules
that are generated due to pre-mature functions and unexpected
exception cases.

**Changelog**
   * Added a PR template
   * Added input data to change the PR status
   * Added skeleton of a facility to handling the specified PR

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>


---