### PR TITLE
config: disabled coverity module by default

### DIFF
--- a/ci/taos/config/config-plugins-prebuild.sh
+++ b/ci/taos/config/config-plugins-prebuild.sh
@@ -154,12 +154,12 @@ echo "[DEBUG] The current path: $(pwd)."
 echo "[DEBUG] source ${REFERENCE_REPOSITORY}/ci/taos/plugins-good/${prebuild_plugins[idx]}.sh"
 source ${REFERENCE_REPOSITORY}/ci/taos/plugins-good/${prebuild_plugins[idx]}.sh
 
-prebuild_plugins[++idx]="pr-prebuild-coverity"
-echo "${prebuild_plugins[idx]} is starting."
-echo "[MODULE] TAOS/${prebuild_plugins[idx]}: Check defects in the C/C++ source code with 'coverity' package"
-echo "[DEBUG] The current path: $(pwd)."
-echo "[DEBUG] source ${REFERENCE_REPOSITORY}/ci/taos/plugins-good/${prebuild_plugins[idx]}.sh"
-source ${REFERENCE_REPOSITORY}/ci/taos/plugins-good/${prebuild_plugins[idx]}.sh
+# prebuild_plugins[++idx]="pr-prebuild-coverity"
+# echo "${prebuild_plugins[idx]} is starting."
+# echo "[MODULE] TAOS/${prebuild_plugins[idx]}: Check defects in the C/C++ source code with 'coverity' package"
+# echo "[DEBUG] The current path: $(pwd)."
+# echo "[DEBUG] source ${REFERENCE_REPOSITORY}/ci/taos/plugins-good/${prebuild_plugins[idx]}.sh"
+# source ${REFERENCE_REPOSITORY}/ci/taos/plugins-good/${prebuild_plugins[idx]}.sh
 
 ##################################################################################################################
 echo "[MODULE] plugins-staging: Plugin group that does not have an evaluation and aging test enough"


### PR DESCRIPTION
This commit is to disable the coverity module by default because
the coverity module requrres 2 conditions as follows to execute
the coverity module.

* Conditions:
   * C1: Administrator must install the Coverity Scan packages.
   * C2: Administrator must set-up a token key in configuration file.

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>


---