### PR TITLE
Tizen: Supported manual profile to handle lots of repos

### DIFF
--- a/ci/taos/config/config-environment.sh
+++ b/ci/taos/config/config-environment.sh
@@ -124,6 +124,11 @@ BUILD_MODE_UBUNTU=99
 BUILD_MODE_YOCTO=99
 BUILD_MODE_ANDROID=99
 
+# Tizen: If each git repository must be defined by a different profile (e.g., ~/.gbs.conf),
+# The name of TIZEN_GBS_PROFILE can be given without the "profile." prefix as follows.
+# For example, [profile.tizen40_mobile] has to be declared with TIZEN_GBS_PROFILE="tizen40_mobile".
+TIZEN_GBS_PROFILE=""
+
 # Pull Request Scheduler: The number of jobs on Run-Queue to process PRs
 RUN_QUEUE_PR_JOBS=8
 

--- a/ci/taos/plugins-base/pr-postbuild-build-tizen.sh
+++ b/ci/taos/plugins-base/pr-postbuild-build-tizen.sh
@@ -66,6 +66,11 @@ function pr-postbuild-build-tizen-run-queue(){
     # Build a package with gbs command.
     # TODO: Simplify the existing if...else statement for readability and maintenance
     echo -e "[DEBUG] gbs build start at : $(date -R)."
+    if [[ "$TIZEN_GBS_PROFILE" != "" ]]; then
+        _TIZEN_GBS_PROFILE="-P ${TIZEN_GBS_PROFILE}"
+    else
+        _TIZEN_GBS_PROFILE=""
+    fi
     if [[ $BUILD_MODE == 99 ]]; then
         echo -e "BUILD_MODE = 99"
         echo -e "Skipping 'gbs build -A $1' procedure temporarily."
@@ -73,6 +78,7 @@ function pr-postbuild-build-tizen-run-queue(){
         echo -e "BUILD_MODE = 1"
         sudo -Hu www-data gbs build \
         -A $1 \
+        ${_TIZEN_GBS_PROFILE} \
         --clean \
         --define "_smp_mflags -j${CPU_NUM}" \
         --define "_pr_context pr-postbuild" \
@@ -87,6 +93,7 @@ function pr-postbuild-build-tizen-run-queue(){
         if [[ $1 == "x86_64" || $1 == "i586" ]]; then
             sudo -Hu www-data gbs build \
             -A $1 \
+            ${_TIZEN_GBS_PROFILE} \
             --clean \
             --define "_smp_mflags -j${CPU_NUM}" \
             --define "_pr_context pr-postbuild" \
@@ -100,6 +107,7 @@ function pr-postbuild-build-tizen-run-queue(){
         else
             sudo -Hu www-data gbs build \
             -A $1 \
+            ${_TIZEN_GBS_PROFILE} \
             --clean \
             --define "_smp_mflags -j${CPU_NUM}" \
             --define "_pr_context pr-postbuild" \


### PR DESCRIPTION
Fixed issue #590.

Tizen: If each git repository must be defined by a different profile (e.g., ~/.gbs.conf),
The name of TIZEN_GBS_PROFILE can be given without the "profile." prefix as follows.
For example, [profile.tizen40_mobile] has to be declared with TIZEN_GBS_PROFILE="tizen40_mobile".
TIZEN_GBS_PROFILE=""

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>


---