### PR TITLE
Fixed incorrect matching expression for webhook

### DIFF
--- a/ci/taos/webhook.php
+++ b/ci/taos/webhook.php
@@ -178,9 +178,10 @@ function check_open_sesame(){
     global $open_sesame;
       echo ("[DEBUG] #### checker: starting '@open sesame' check routine \n");
        $pr_title=$payload->{"pull_request"}->{"title"};
-       $pattern="/@open sesame[^.]+\/+[^.]+\:+[^.]/i";
+       $pattern="/@open sesame[^.]+\/+[^.]+\:+[^.]+$/i";
        if (preg_match($pattern, $pr_title, $matches)) {
         echo "[DEBUG] '@open sesame' is enabled. a matched data is '".$matches[0]."'. \n";
+        echo "[DEBUG] PR title is '".$pr_title."'. \n";
            $open_sesame="true";
        }
        else {


### PR DESCRIPTION
This commit is to fix incorrect usage of the regular expression
when the wehook handler (PHP) check "@open sesame" tag.

* Input (PR title): a model is updatable - @open sesame 12/03 16:47
* Before this PR: "@open sesame 12/03 16:4"
* After  this PR: "@open sesame 12/03 16:47"

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>


---