### PR TITLE
webapp: Added unit-test result folder

### DIFF
--- a/ci/taos/menu.html
+++ b/ci/taos/menu.html
@@ -44,6 +44,7 @@
             <option value="/" selected>[ PR: details ]</option>
             <option value="./webhook.php">Webhook Handler</option>
             <option value="../gcov_html/">Code Coverage</option>
+            <option value="../unittest_result/">Gtest(UnitTest Result)</option>
             <option value="../repo-workers/?C=M;O=D/">PR: Report Archive</option>
             <option value="../taos/webapp/monitor.php">PR: Running PRs</option>
             <option value="../taos/webapp/top.php">PR: Resource Usage(top)</option>

--- a/ci/unittest_result/README.txt
+++ b/ci/unittest_result/README.txt
@@ -1,0 +1,18 @@
+
+
+ Gtest-based UnitTest Report
+===============================
+
+This section describes how to get the report file after running the unit-tests based on Gtest.
+The below statements show how to run this auto-unittest script at specified time every day.
+The auto-unittet.sch is written by the Tizen gbs and Google Gtest.
+* https://source.tizen.org/documentation/reference/git-build-system/usage/gbs-build
+* https://github.com/google/googletest
+
+## Example
+$ sudo vi /etc/crontab
+30 7 * * * www-data /var/www/html/nnstreamer/ci/taos/auto-unittest.sh
+
+
+## Repot
+The result files are archived into the ./ci/unittest_result/ folder.


### PR DESCRIPTION
This commit is to append the archive folder of the unit-test.
The unit-test could be executed by Tizen GBS and Google Gtest.

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>


---