### PR TITLE
Maintenance: Change name of two groups for readability

### DIFF
--- a/ci/taos/checker-pr-postbuild-async.sh
+++ b/ci/taos/checker-pr-postbuild-async.sh
@@ -141,7 +141,7 @@ echo "[DEBUG] source ${REFERENCE_REPOSITORY}/ci/taos/config/config-plugins-postb
 
 # Create new context name to monitor progress status of a checker
 message="Trigger: wait queue. There are other build jobs and we need to wait.. The commit number is $input_commit."
-cibot_report $TOKEN "pending" "(INFO)${BOT_NAME}/pr-postbuild-all" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+cibot_report $TOKEN "pending" "(INFO)${BOT_NAME}/pr-postbuild-group" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
 
 for plugin in ${postbuild_plugins[*]}
 do
@@ -223,7 +223,7 @@ popd
 # users of current status of a pull request.
 
 message="Trigger: wait queue. The commit number is $input_commit."
-cibot_report $TOKEN "pending" "(INFO)${BOT_NAME}/pr-postbuild-all" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+cibot_report $TOKEN "pending" "(INFO)${BOT_NAME}/pr-postbuild-group" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
 
 for plugin in ${postbuild_plugins[*]}
 do
@@ -247,7 +247,7 @@ done
 # if the current status of pull reqeust is building or not.
 
 message="Trigger: run queue. The commit number is $input_commit."
-cibot_report $TOKEN "pending" "(INFO)${BOT_NAME}/pr-postbuild-all" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+cibot_report $TOKEN "pending" "(INFO)${BOT_NAME}/pr-postbuild-group" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
 
 for plugin in ${postbuild_plugins[*]}
 do
@@ -325,20 +325,20 @@ exit_code=0
 if [[ $global_check_result == "success" ]]; then
     # The global check is succeeded.
     message="Successfully all postbuild modules are passed. Commit number is $input_commit."
-    cibot_report $TOKEN "success" "(INFO)${BOT_NAME}/pr-postbuild-all" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+    cibot_report $TOKEN "success" "(INFO)${BOT_NAME}/pr-postbuild-group" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
 
     # If contributors want later, let's inform developers of CI test result to go to a review process as a final step before merging a PR
-    echo "[DEBUG] All postbuild modules are passed - it is ready to review! :shipit:. Note that CI bot has two sub-bots such as ${BOT_NAME}/pr-postbuild-all and ${BOT_NAME}/pr-prebuild-all."
+    echo "[DEBUG] All postbuild modules are passed - it is ready to review! :shipit:. Note that CI bot has two sub-bots such as ${BOT_NAME}/pr-postbuild-group and ${BOT_NAME}/pr-prebuild-group."
 
 elif [[ $global_check_result == "failure" ]]; then
     # The global check is failed.
     message="Oooops. One of the postbuild modules is failed. Resubmit the PR after fixing correctly. Commit number is $input_commit."
-    cibot_report $TOKEN "failure" "(INFO)${BOT_NAME}/pr-postbuild-all" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+    cibot_report $TOKEN "failure" "(INFO)${BOT_NAME}/pr-postbuild-group" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
     exit_code=1
 else
     # The global check is failed due to CI error.
     message="CI Error. There is a bug in CI script. Please contact the CI administrator."
-    cibot_report $TOKEN "error" "(INFO)${BOT_NAME}/pr-postbuild-all" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+    cibot_report $TOKEN "error" "(INFO)${BOT_NAME}/pr-postbuild-group" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
     echo -e "[DEBUG] It seems that this script has a bug. Please check value of \$global_check_result."
     exit_code=1
 fi

--- a/ci/taos/checker-pr-prebuild-async.sh
+++ b/ci/taos/checker-pr-prebuild-async.sh
@@ -106,7 +106,7 @@ cd $dir_ci
 export dir_commit=${dir_worker}/${input_pr}-${input_date}-${input_commit}
 # --------------------------- CI Trigger (queued) --------------------------------------------------------------------
 message="Trigger: queued. The commit number is $input_commit."
-cibot_report $TOKEN "pending" "(INFO)${BOT_NAME}/pr-prebuild-all" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+cibot_report $TOKEN "pending" "(INFO)${BOT_NAME}/pr-prebuild-group" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
 
 
 
@@ -166,17 +166,17 @@ echo -e "[DEBUG] Varaible global_check_result is $global_check_result."
 if [[ $global_check_result == "success" ]]; then
     # in case of success
     message="Successfully all modules of the prebuild group are done."
-    cibot_report $TOKEN "success" "(INFO)${BOT_NAME}/pr-prebuild-all" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
-    echo -e "[DEBUG] cibot_report $TOKEN success (INFO)${BOT_NAME}/pr-prebuild-all $message ${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/ ${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+    cibot_report $TOKEN "success" "(INFO)${BOT_NAME}/pr-prebuild-group" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+    echo -e "[DEBUG] cibot_report $TOKEN success (INFO)${BOT_NAME}/pr-prebuild-group $message ${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/ ${GITHUB_WEBHOOK_API}/statuses/$input_commit"
 
     # inform PR submitter of success content to encourage review process
-    echo -e "[DEBUG] (INFO)${BOT_NAME}/pr-prebuild-all: All modules of the prebuld group are passed - it is ready to review!"
-    echo -e "[DEBUG] :shipit: Note that CI bot has two sub-bots such as ${BOT_NAME}/pr-postbuild-all and ${BOT_NAME}/pr-prebuild-all."
+    echo -e "[DEBUG] (INFO)${BOT_NAME}/pr-prebuild-group: All modules of the prebuld group are passed - it is ready to review!"
+    echo -e "[DEBUG] :shipit: Note that CI bot has two sub-bots such as ${BOT_NAME}/pr-postbuild-group and ${BOT_NAME}/pr-prebuild-group."
 
 elif [[ $global_check_result == "failure" ]]; then
     # in case of failure
     message="Oooops. There is a failed module of the prebuild group. Update your code correctly after reading error messages."
-    cibot_report $TOKEN "failure" "(INFO)${BOT_NAME}/pr-prebuild-all" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+    cibot_report $TOKEN "failure" "(INFO)${BOT_NAME}/pr-prebuild-group" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
 
     # inform PR submitter of a hint to fix issues
     message=":octocat: **cibot**: $user_id, One of the module of prebuild group is failed. If you want to get a hint to fix this issue, please go to ${REPOSITORY_WEB}/wiki/."
@@ -186,7 +186,7 @@ elif [[ $global_check_result == "failure" ]]; then
 else
     # in case that CI is broken
     message="Oooops. It seems that CI bot has bug(s). CI bot has to be fixed."
-    cibot_report $TOKEN "failure" "(INFO)${BOT_NAME}/pr-prebuild-all" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
+    cibot_report $TOKEN "failure" "(INFO)${BOT_NAME}/pr-prebuild-group" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
     exit_code=1
 
 fi

--- a/ci/taos/plugins-base/pr-postbuild-build-android.sh
+++ b/ci/taos/plugins-base/pr-postbuild-build-android.sh
@@ -259,9 +259,9 @@ function pr-postbuild-build-android-run-queue(){
         cibot_report $TOKEN "success" "${BOT_NAME}/pr-postbuild-build-android" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
 
         message="Skipped the ndk-build procedure. Successfully all postbuild modules are passed. Commit number is $input_commit."
-        cibot_report $TOKEN "success" "(INFO)${BOT_NAME}/pr-postbuild-all" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+        cibot_report $TOKEN "success" "(INFO)${BOT_NAME}/pr-postbuild-group" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
 
-        echo -e "[DEBUG] The ndk-build procedure is skipped - it is ready to review! :shipit: Note that CI bot has two sub-bots such as ${BOT_NAME}/pr-postbuild-all and ${BOT_NAME}/pr-prebuild-all."
+        echo -e "[DEBUG] The ndk-build procedure is skipped - it is ready to review! :shipit: Note that CI bot has two sub-bots such as ${BOT_NAME}/pr-postbuild-group and ${BOT_NAME}/pr-prebuild-group."
     else
         echo -e "BUILD_MODE != 99"
         echo -e "[DEBUG] The return value of ndk-build command is $result."

--- a/ci/taos/plugins-base/pr-postbuild-build-tizen.sh
+++ b/ci/taos/plugins-base/pr-postbuild-build-tizen.sh
@@ -154,7 +154,7 @@ function pr-postbuild-build-tizen-run-queue(){
         cibot_report $TOKEN "success" "${BOT_NAME}/pr-postbuild-build-tizen-$1" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
 
         message="Skipped gbs build -A $1 procedure. Successfully all postbuild modules are passed. Commit number is $input_commit."
-        cibot_report $TOKEN "success" "(INFO)${BOT_NAME}/pr-postbuild-all" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+        cibot_report $TOKEN "success" "(INFO)${BOT_NAME}/pr-postbuild-group" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
 
         echo -e "[DEBUG] All postbuild modules are passed (gbs build -A $1 procedure is skipped) - it is ready to review!"
     else

--- a/ci/taos/plugins-base/pr-postbuild-build-ubuntu.sh
+++ b/ci/taos/plugins-base/pr-postbuild-build-ubuntu.sh
@@ -139,9 +139,9 @@ function pr-postbuild-build-ubuntu-run-queue(){
         cibot_report $TOKEN "success" "${BOT_NAME}/pr-postbuild-build-ubuntu" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
 
         message="Skipped pdebuild procedure. Successfully all postbuild modules are passed. Commit number is $input_commit."
-        cibot_report $TOKEN "success" "(INFO)${BOT_NAME}/pr-postbuild-all" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+        cibot_report $TOKEN "success" "(INFO)${BOT_NAME}/pr-postbuild-group" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
 
-        echo -e "[DEBUG] pdebuild procedure is skipped - it is ready to review! :shipit: Note that CI bot has two sub-bots such as ${BOT_NAME}/pr-postbuild-all and ${BOT_NAME}/pr-prebuild-all."
+        echo -e "[DEBUG] pdebuild procedure is skipped - it is ready to review! :shipit: Note that CI bot has two sub-bots such as ${BOT_NAME}/pr-postbuild-group and ${BOT_NAME}/pr-prebuild-group."
     else
         echo -e "BUILD_MODE != 99"
         echo -e "[DEBUG] The return value of pdebuild command is $result."

--- a/ci/taos/plugins-base/pr-postbuild-build-yocto.sh
+++ b/ci/taos/plugins-base/pr-postbuild-build-yocto.sh
@@ -183,9 +183,9 @@ function pr-postbuild-build-yocto-run-queue(){
         cibot_report $TOKEN "success" "${BOT_NAME}/pr-postbuild-build-yocto" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
 
         message="Skipped devtool procedure. Successfully all postbuild modules are passed. Commit number is $input_commit."
-        cibot_report $TOKEN "success" "(INFO)${BOT_NAME}/pr-postbuild-all" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+        cibot_report $TOKEN "success" "(INFO)${BOT_NAME}/pr-postbuild-group" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
 
-        echo -e "[DEBUG] devtool procedure is skipped - it is ready to review! :shipit: Note that CI bot has two sub-bots such as ${BOT_NAME}/pr-postbuild-all and ${BOT_NAME}/pr-prebuild-all."
+        echo -e "[DEBUG] devtool procedure is skipped - it is ready to review! :shipit: Note that CI bot has two sub-bots such as ${BOT_NAME}/pr-postbuild-group and ${BOT_NAME}/pr-prebuild-group."
     elif [[ $YOCTO_ESDK_NAME == "" ]]; then
         # Do not run "devtool" command in order to skip unnecessary examination if there eSDK is not installed by administrator.
         echo -e "YOCTO_ESDK_NAME == ''"
@@ -196,9 +196,9 @@ function pr-postbuild-build-yocto-run-queue(){
         cibot_report $TOKEN "success" "${BOT_NAME}/pr-postbuild-build-yocto" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
 
         message="Skipped devtool procedure. Successfully all postbuild modules are passed. Commit number is $input_commit."
-        cibot_report $TOKEN "success" "(INFO)${BOT_NAME}/pr-postbuild-all" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
+        cibot_report $TOKEN "success" "(INFO)${BOT_NAME}/pr-postbuild-group" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
 
-        echo -e "[DEBUG] devtool procedure is skipped - it is ready to review! :shipit: Note that CI bot has two sub-bots such as ${BOT_NAME}/pr-postbuild-all and ${BOT_NAME}/pr-prebuild-all."
+        echo -e "[DEBUG] devtool procedure is skipped - it is ready to review! :shipit: Note that CI bot has two sub-bots such as ${BOT_NAME}/pr-postbuild-group and ${BOT_NAME}/pr-prebuild-group."
     else
         echo -e "BUILD_MODE != 99"
         echo -e "[DEBUG] The return value of devtool command is $build_result."


### PR DESCRIPTION
This commit is to change the existing group name from "pr-{pre/post}-all"
to "pr-{pre/post}-group" to improve readability and clarify the meaning of
group name (e.g., prebuild group and postbuild group).

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>


---