### PR TITLE
[Apptest] enable tf-lite

### DIFF
--- a/ci/taos/plugins-staging/pr-postbuild-nnstreamer-ubuntu-apptest.sh
+++ b/ci/taos/plugins-staging/pr-postbuild-nnstreamer-ubuntu-apptest.sh
@@ -162,7 +162,7 @@ function pr-postbuild-nnstreamer-ubuntu-apptest-run-queue() {
     fi
 
     # Build a source code of the nnstreamer repository
-    meson --prefix=${NNST_ROOT} --sysconfdir=${NNST_ROOT} --libdir=lib --bindir=bin --includedir=include build
+    meson --prefix=${NNST_ROOT} --sysconfdir=${NNST_ROOT} --libdir=lib --bindir=bin --includedir=include -Denable-tensorflow-lite=true -Denable-tensorflow=true build
 
     # Install a nnstreamer library
     ninja -C build install


### PR DESCRIPTION
To run tf-lite model in apptest, it is necessary to enable tensorflow-lite.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
