### PR TITLE
[gbs] Let tizen gbs build use cache properly

### DIFF
--- a/ci/taos/checker-pr-postbuild-async.sh
+++ b/ci/taos/checker-pr-postbuild-async.sh
@@ -336,5 +336,13 @@ fi
 # Please append a command below.
 echo -e "[DEBUG] The current directory: $(pwd)."
 
+echo -e "[DEBUG] Remove the GBS-ROOT folder."
+sudo rm -rf ./GBS-ROOT/
+if [[ $? -eq 0 ]]; then
+    echo -e "[DEBUG] Successfully removed the GBS-ROOT folder."
+else
+    echo -e "[WARN] Failed to remove the GBS-ROOT folder."
+fi
+
 # Return with exit code
 exit $exit_code

--- a/ci/taos/plugins-base/pr-postbuild-build-tizen.sh
+++ b/ci/taos/plugins-base/pr-postbuild-build-tizen.sh
@@ -172,12 +172,12 @@ function pr-postbuild-build-tizen-run-queue(){
         echo "Archiving .rpm files for $1 ..."
         ls -al  ./GBS-ROOT/local/repos/tizen/$1/RPMS/
         sudo cp -arf ./GBS-ROOT/local/repos/tizen/$1/RPMS ../$PACK_BIN_FOLDER || echo -e "[DEBUG] Can't copy .rpm files."
-        echo "Removing ./GBS-ROOT/ folder..."
-        sudo rm -rf ./GBS-ROOT/
+        echo "Removing ./GBS-ROOT/local/BUILD-ROOTS/ folder..."
+        sudo rm -rf ./GBS-ROOT/local/BUILD-ROOTS/
         if [[ $? -ne 0 ]]; then
-            echo "[DEBUG][FAILED] Tizen/gbs: Oooops!!!!! ./GBS-ROOT folder is not removed."
+            echo "[DEBUG][FAILED] Tizen/gbs: Oooops!!!!! ./GBS-ROOT/local/BUILD-ROOTS/ folder is not removed."
         else
-            echo "[DEBUG][PASSED] Tizen/gbs: It is okay. ./GBS-ROOT folder is successfully removed."
+            echo "[DEBUG][PASSED] Tizen/gbs: It is okay. ./GBS-ROOT/local/BUILD-ROOTS/ folder is successfully removed."
         fi
     fi
     echo "[DEBUG] The current directory: $(pwd)"


### PR DESCRIPTION
- Currently only the first arch option use the gbs build cache.
- Remove GBS-ROOT folder when all the tizen gbs build is finished.
- Expecting quite a time boost on gbs build tasks by removing rpm downloading.

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ] Skipped
